### PR TITLE
Password reset

### DIFF
--- a/transport_nantes/authentication/templates/authentication/account_activation_invalid.html
+++ b/transport_nantes/authentication/templates/authentication/account_activation_invalid.html
@@ -2,5 +2,5 @@
 {% load static %}
 
 {% block content %}
-  <p>The confirmation link was invalid, possibly because it has already been used.</p>
+  <p>Le lien de confirmation est invalide. Peut-être qu'il a déjà été utilisé ou qu'il a expiré.</p>
 {% endblock %}

--- a/transport_nantes/authentication/templates/authentication/account_activation_sent.html
+++ b/transport_nantes/authentication/templates/authentication/account_activation_sent.html
@@ -7,13 +7,13 @@
 	<div class="col-lg-12">
 	    {% if is_new %}
 	    <h1>Merci !</h1>
-	    <p>Un mél est un route pour que vous puissiez confirmer la
+	    <p>Un mail est un route pour que vous puissiez confirmer la
 		création de votre compte.
 	    </p>
 	    {% else %}
 	    <h1>C'est parti</h1>
-	    <p>Un mél est un route avec un lien magique qui vous permettra
-		de connecter.
+	    <p>Un mail est un route avec un lien magique qui vous permettra
+		de vous connecter.
 	    </p>
 	    {% endif %}
 	</div>

--- a/transport_nantes/authentication/templates/authentication/home.html
+++ b/transport_nantes/authentication/templates/authentication/home.html
@@ -2,6 +2,6 @@
 {% load static %}
 
 {% block content %}
-  <h2>Welcome, {{ user.get_full_name }} <small>{{ user.username }}</small>!</h2>
-  <p>Thanks for confirming your email address!</p>
+  <h2>Bienvenue, {{ user.get_full_name }} <small>{{ user.username }}</small>!</h2>
+  <p>Merci d'avoir confirmer votre adresse mail!</p>
 {% endblock %}

--- a/transport_nantes/authentication/templates/authentication/login.html
+++ b/transport_nantes/authentication/templates/authentication/login.html
@@ -66,6 +66,7 @@
 		    mot de passe, tapez-le une deuxième fois.</p>
 		<button type="submit" class="btn btn-outline-secondary">Inscription</button>
 	    </form>
+		<p><a href="{% url 'password_reset' %}">Mot de passe oublié?</a></p>
 	</div>
     </div>
 </div>

--- a/transport_nantes/authentication/templates/authentication/login.html
+++ b/transport_nantes/authentication/templates/authentication/login.html
@@ -29,9 +29,9 @@
 		<p style="color: red">{{ error }}</p>
 		{% endfor %}
 		<p class="text-secondary">C'est tout ce qu'il faut !
-		    Vous recevrez un mél pour valider votre connexion.
+		    Vous recevrez un mail pour valider votre connexion.
 		    Si vous n'avez pas déjà de compte, votre première connexion
-		    en créerait un.
+		    en créera un.
 		</p>
 		<p>
 		    {{ form.password1.label }}<br>
@@ -44,10 +44,10 @@
 		<p style="color: red">{{ error }}</p>
 		{% endfor %}
 		<p class="text-secondary">
-		    Sans mot de passe, vous recevrait un mél avec un
+		    Sans mot de passe, vous recevrez un mail avec un
 		    lien pour valider votre connexion.  Si vous avez
 		    oublié votre mot de passe, connectez sans, vous
-		    recevrez un mél pour vous connecter.
+		    recevrez un mail pour vous connecter.
 		</p>
 		<button type="submit" class="btn btn-outline-primary">Connexion</button>
 

--- a/transport_nantes/authentication/templates/authentication/profile.html
+++ b/transport_nantes/authentication/templates/authentication/profile.html
@@ -10,11 +10,11 @@
 	    <form method="POST" enctype="multipart/form-data">
 		{% csrf_token %}
 		<fieldset class="form-group">
-		    <legend class="border-bottom mb-4">Profile Info</legend>
+		    <legend class="border-bottom mb-4">Information du compte</legend>
 		    {{ u_form.as_p }}
 		    {{ p_form.as_p }}
 		</fieldset>
-		<button type="submit">Update</button>
+		<button type="submit">Mise à jour</button>
 	    </form>
 	</div>
     </div>

--- a/transport_nantes/authentication/templates/registration/password_reset_complete.html
+++ b/transport_nantes/authentication/templates/registration/password_reset_complete.html
@@ -1,0 +1,12 @@
+{% extends 'asso_tn/base_transport_nantes.html' %}
+{% load static %}
+
+{% block app_content %}
+
+<div class="container">
+	<div class="d-flex flex-column">
+		<p class="m-auto">Votre mot de passe a été réinitialisé. Vous pouvez vous <a href="{% url 'authentication:login' %}">connecter</a>.</p>
+	</div>
+</div>
+
+{% endblock %}

--- a/transport_nantes/authentication/templates/registration/password_reset_confirm.html
+++ b/transport_nantes/authentication/templates/registration/password_reset_confirm.html
@@ -1,0 +1,22 @@
+{% extends 'asso_tn/base_transport_nantes.html' %}
+{% load static %}
+
+{% block app_content %}
+
+{% if validlink %}
+
+<h1>Changer de mot de passe</h1>
+<form method="POST">
+  {% csrf_token %}
+  
+        <p>Nouveau mot de passe: <br> {{form.new_password1}}</p>
+        <p>Répeter le mot de passe <br> {{form.new_password2}}</p>
+  <input type="submit" value="Changer mon mot de passe">
+</form>
+
+{% else %}
+
+<p>Le lien de réinitialisation du mot de passe est invalide, peut-être a-t'il déjà été utilisé. Veuillez faire une nouvelle demande de réinitialisation.</p>
+
+{% endif %}
+{% endblock %}

--- a/transport_nantes/authentication/templates/registration/password_reset_done.html
+++ b/transport_nantes/authentication/templates/registration/password_reset_done.html
@@ -1,0 +1,21 @@
+{% extends 'asso_tn/base_transport_nantes.html' %}
+{% load static %}
+
+{% block app_content %}
+
+<div class="container">
+
+	<div class="d-flex flex-column">
+		  <p class="m-auto p-2">
+		    Nous vous avons envoyé un mél d'instructions pour réinitialiser votre mot de passe. 
+            Vous allez le recevoir sous peu.
+		  </p>
+		  <p class="m-auto p-2">
+		    Si vous n'avez pas reçu de mél, veuillez vérifier que vous avez entré l'adresse avec laquelle vous
+            vous êtes enregistré and vérifiez vos spams.
+		  </p>
+		  <p class="m-auto p-2"><a href="{% url 'index' %}">Retour à la page d'accueil</a></p>
+	</div>
+</div>
+
+{% endblock %}

--- a/transport_nantes/authentication/templates/registration/password_reset_email.html
+++ b/transport_nantes/authentication/templates/registration/password_reset_email.html
@@ -1,0 +1,11 @@
+{% autoescape off %}
+Veuillez cliquer sur le lien ci-dessous pour lancer la procédure de réinitialisation de mot de passe 
+pour le compte {{ user.email }},
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+Copiez le lien et collez le dans la barre URL de votre navigateur si le lien ne fonctionne pas.
+
+Cordialement,
+L'équipe de Transport Nantes
+{% endautoescape %}

--- a/transport_nantes/authentication/templates/registration/password_reset_form.html
+++ b/transport_nantes/authentication/templates/registration/password_reset_form.html
@@ -1,0 +1,45 @@
+{% extends 'asso_tn/base_transport_nantes.html' %}
+{% load static %}
+
+
+{% block app_content %}
+
+<style type="text/css">
+  .form-signin {
+    width: 100%;
+    max-width: 330px;
+    padding: 15px;
+    margin: auto;
+  }
+  .form-signin .checkbox {
+    font-weight: 400;
+  }
+  .form-signin .form-control {
+    position: relative;
+    box-sizing: border-box;
+    height: auto;
+    padding: 10px;
+    font-size: 16px;
+  }
+  .form-signin .form-control:focus {
+    z-index: 2;
+  }
+  .form-signin input[type="email"] {
+    margin-bottom: 10px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .h3{
+    text-align: center;
+  }
+</style>
+
+
+<form method="POST" class="form-signin">{% csrf_token %}
+	<h1 class="h3 mb-3 font-weight-normal">Réinitialisation du mot de passe</h1>
+    <input name="email" class="form-control" placeholder="Adresse mail" type="email" id="id_email" required="true">
+	<button class="btn btn-lg btn-primary btn-block" type="submit">Envoyer le mail</button>  
+</form>
+
+{% endblock %}

--- a/transport_nantes/authentication/templates/registration/password_reset_subject.txt
+++ b/transport_nantes/authentication/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Transport Nantes - Réinitialisation du mot de passe

--- a/transport_nantes/authentication/tests.py
+++ b/transport_nantes/authentication/tests.py
@@ -7,6 +7,7 @@ import authentication.views as views
 from asso_tn.utils import make_timed_token
 from django.utils.crypto import get_random_string
 from time import sleep
+from captcha.models import CaptchaStore
 
 # Create your tests here.
 
@@ -23,10 +24,12 @@ class UserTest(TestCase):
         site.name = "localhost"
         site.save()
 
+        # Set captcha
+        captcha = CaptchaStore.objects.get(hashkey=CaptchaStore.generate_key())
         # Set parameters to similate POST
         context = { "email": "test1@truc.com",
-                     'captcha_0': "captcha",
-                     'captcha_1': "PASSED" }
+                     'captcha_0': captcha.hashkey,
+                     'captcha_1': captcha.response }
         request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
 
         # Call .views.login()
@@ -68,10 +71,12 @@ class UserTest(TestCase):
             existing_test_user = False
         self.assertIs(existing_test_user, True)
 
+        # Set captcha
+        captcha = CaptchaStore.objects.get(hashkey=CaptchaStore.generate_key())
         # Set parameters to similate POST
         context = { "email": "test1@truc.com",
-                     'captcha_0': "captcha",
-                     'captcha_1': "PASSED" }
+                     'captcha_0': captcha.hashkey,
+                     'captcha_1': captcha.response }
         request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
 
         # Call .views.login()
@@ -113,10 +118,12 @@ class UserTest(TestCase):
             existing_test_user = False
         self.assertIs(existing_test_user, True)
 
+        # Set captcha
+        captcha = CaptchaStore.objects.get(hashkey=CaptchaStore.generate_key())
         # Set parameters to similate POST
         context = { "email": "test1@truc.com",
-                     'captcha_0': "captcha",
-                     'captcha_1': "PASSED" }
+                     'captcha_0': captcha.hashkey,
+                     'captcha_1': captcha.response }
         request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
         
         # Call .views.login()
@@ -153,10 +160,12 @@ class UserTest(TestCase):
         self.assertGreaterEqual(test_user_count, 2)
         self.assertIs(existing_test_user, True)
 
+        # Set captcha
+        captcha = CaptchaStore.objects.get(hashkey=CaptchaStore.generate_key())
         # Set parameters to similate POST
         context = { "email": "test@truc.com",
-                     'captcha_0': "captcha",
-                     'captcha_1': "PASSED" }
+                     'captcha_0': captcha.hashkey,
+                     'captcha_1': captcha.response }
         request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
         
         # Call .views.login()

--- a/transport_nantes/authentication/tests.py
+++ b/transport_nantes/authentication/tests.py
@@ -35,14 +35,9 @@ class UserTest(TestCase):
         # Call .views.login()
         login_response = views.login(request)
 
-        # Test good site page calling
-        self.assertEqual(login_response.url, "/auth/account_activation_sent/True")
-
-        # Get account_activation_sent page
-        sent_activation_response = self.client.get(login_response.url)
         # Test good printing of the page
         self.assertInHTML("Un mél est un route pour que vous puissiez confirmer la création de votre compte.",
-            sent_activation_response.content.decode("utf-8"))
+            login_response.content.decode("utf-8"))
 
         # Get user and test creation in User table
         try:
@@ -82,14 +77,9 @@ class UserTest(TestCase):
         # Call .views.login()
         login_response = views.login(request)
 
-        # Test good site page calling
-        self.assertEqual(login_response.url, "/auth/account_activation_sent/True")
-
-        # Get account_activation_sent page
-        sent_activation_response = self.client.get(login_response.url)
         # Test good printing of the page
         self.assertInHTML("Un mél est un route pour que vous puissiez confirmer la création de votre compte.",
-            sent_activation_response.content.decode("utf-8"))
+            login_response.content.decode("utf-8"))
         
         # Get user and test creation in User table
         try:
@@ -129,14 +119,9 @@ class UserTest(TestCase):
         # Call .views.login()
         login_response = views.login(request)
 
-        # Test good site page calling
-        self.assertEqual(login_response.url, "/auth/account_activation_sent/False")
-
-        # Get account_activation_sent page
-        sent_activation_response = self.client.get(login_response.url)
         # Test good printing of the page
         self.assertInHTML("Un mél est un route avec un lien magique qui vous permettra de connecter.",
-            sent_activation_response.content.decode("utf-8"))
+            login_response.content.decode("utf-8"))
         
     # Minimum of 2 user with the same mail in database and test site page shown
     def test_two_users_with_same_mail(self):

--- a/transport_nantes/authentication/tests.py
+++ b/transport_nantes/authentication/tests.py
@@ -1,3 +1,163 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+import authentication.views as views
 
 # Create your tests here.
+
+# TODO Test good printing of pages (first print, post, redirect) and also page needing token from mail
+# TODO Test adding of new user if account doesn't exist and if account already exists
+class UserTest(TestCase):
+
+    # Add new user and test site page shown
+    def test_add_new_user(self):
+
+        # Set site into Site table
+        site = Site.objects.get(id=1)
+        site.domain = "localhost:8000"
+        site.name = "localhost"
+        site.save()
+
+        # Set parameters to similate POST
+        context = { "email": "test1@truc.com",
+                     'captcha_0': "captcha",
+                     'captcha_1': "PASSED" }
+        request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
+
+        # Call .views.login()
+        login_response = views.login(request)
+
+        # Test good site page calling
+        self.assertEqual(login_response.url, "/auth/account_activation_sent/True")
+
+        # Get account_activation_sent page
+        sent_activation_response = self.client.get(login_response.url)
+        # Test good printing of the page
+        self.assertInHTML("Un mél est un route pour que vous puissiez confirmer la création de votre compte.",
+            sent_activation_response.content.decode("utf-8"))
+
+        # Get user and test creation in User table
+        try:
+            user = User.objects.get(email="test1@truc.com")
+            existing_user = True
+        except:
+            existing_user = False
+        self.assertIs(existing_user, True)
+
+    # Add new user with different mail of existing user and test site page shown
+    def test_add_new_user_with_different_mail(self):
+
+        # Set site into Site table
+        site = Site.objects.get(id=1)
+        site.domain = "localhost:8000"
+        site.name = "localhost"
+        site.save()
+
+        # Add existing user in database
+        User.objects.create_user(username="test_user", email="test_user@truc.com")
+        # Test addition of user
+        try:
+            test_user = User.objects.get(email="test_user@truc.com")
+            existing_test_user = True
+        except:
+            existing_test_user = False
+        self.assertIs(existing_test_user, True)
+
+        # Set parameters to similate POST
+        context = { "email": "test1@truc.com",
+                     'captcha_0': "captcha",
+                     'captcha_1': "PASSED" }
+        request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
+
+        # Call .views.login()
+        login_response = views.login(request)
+
+        # Test good site page calling
+        self.assertEqual(login_response.url, "/auth/account_activation_sent/True")
+
+        # Get account_activation_sent page
+        sent_activation_response = self.client.get(login_response.url)
+        # Test good printing of the page
+        self.assertInHTML("Un mél est un route pour que vous puissiez confirmer la création de votre compte.",
+            sent_activation_response.content.decode("utf-8"))
+        
+        # Get user and test creation in User table
+        try:
+            user = User.objects.get(email="test1@truc.com")
+            existing_user = True
+        except:
+            existing_user = False
+        self.assertIs(existing_user, True)
+
+    # Add new user with same mail of existing user and test site page shown
+    def test_add_new_user_with_same_mail(self):
+
+        # Set site into Site table
+        site = Site.objects.get(id=1)
+        site.domain = "localhost:8000"
+        site.name = "localhost"
+        site.save()
+
+        # Add existing user in database
+        User.objects.create_user(username="test_user", email="test1@truc.com")
+        # Test addition of user
+        try:
+            test_user = User.objects.get(email="test1@truc.com")
+            existing_test_user = True
+        except:
+            existing_test_user = False
+        self.assertIs(existing_test_user, True)
+
+        # Set parameters to similate POST
+        context = { "email": "test1@truc.com",
+                     'captcha_0': "captcha",
+                     'captcha_1': "PASSED" }
+        request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
+        
+        # Call .views.login()
+        login_response = views.login(request)
+
+        # Test good site page calling
+        self.assertEqual(login_response.url, "/auth/account_activation_sent/False")
+
+        # Get account_activation_sent page
+        sent_activation_response = self.client.get(login_response.url)
+        # Test good printing of the page
+        self.assertInHTML("Un mél est un route avec un lien magique qui vous permettra de connecter.",
+            sent_activation_response.content.decode("utf-8"))
+        
+    # Minimum of 2 user with the same mail in database and test site page shown
+    def test_two_users_with_same_mail(self):
+
+        # Set site into Site table
+        site = Site.objects.get(id=1)
+        site.domain = "localhost:8000"
+        site.name = "localhost"
+        site.save()
+
+        # Add existing user in database
+        User.objects.create_user(username="test_user1", email="test@truc.com")
+        User.objects.create_user(username="test_user2", email="test@truc.com")
+        # Test addition of user and that number of users superior to 1
+        try:
+            test_user_count = User.objects.count()
+            test_user = User.objects.filter(email="test@truc.com")
+            existing_test_user = True
+        except:
+            existing_test_user = False
+        self.assertGreaterEqual(test_user_count, 2)
+        self.assertIs(existing_test_user, True)
+
+        # Set parameters to similate POST
+        context = { "email": "test@truc.com",
+                     'captcha_0': "captcha",
+                     'captcha_1': "PASSED" }
+        request = RequestFactory().post(reverse("authentication:login"), context, follow=True)
+        
+        # Call .views.login()
+        login_response = views.login(request)
+        
+        # Test printed error message
+        self.assertIn(login_response.content.decode("utf-8"), "Data error: Multiple email addresses found")

--- a/transport_nantes/authentication/urls.py
+++ b/transport_nantes/authentication/urls.py
@@ -29,9 +29,6 @@ urlpatterns = [
     path('in', views.login, name='login'),
     path('out', views.DeauthView.as_view(), name='logout'),
     path('mod', views.profile, name='mod'),
-    path('account_activation_sent/<is_new>',
-         views.account_activation_sent,
-         name='account_activation_sent'),
     path('activate/<token>', views.activate, name='activate'),
 
 ]

--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -110,7 +110,7 @@ def activate(request, token):
     """
     user_id = token_valid(token)
     if user_id < 0:
-        return render(request, 'account_activation_invalid.html')
+        return render(request, 'authentication/account_activation_invalid.html')
     try:
         user = User.objects.get(pk=user_id)
         user.is_active = True

--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -46,7 +46,7 @@ def login(request):
                 user.refresh_from_db()
                 if user.profile.authenticates_by_mail:
                     send_activation(request, user)
-                    return redirect('authentication:account_activation_sent', is_new=False)
+                    return render(request, 'authentication/account_activation_sent.html', {'is_new': False})
             except ObjectDoesNotExist:
                 print('ObjectDoesNotExist')
                 pass            # I'm not sure this can ever happen.
@@ -62,13 +62,13 @@ def login(request):
                 existing_user = existing_users[0]
                 if existing_user.profile.authenticates_by_mail:
                     send_activation(request, existing_user)
-                    return redirect('authentication:account_activation_sent', is_new=False)
+                    return render(request, 'authentication/account_activation_sent.html', {'is_new': False})
             user.email = form.cleaned_data['email']
             user.username = get_random_string(20)
             user.is_active = False
             user.save()
             send_activation(request, user)
-            return redirect('authentication:account_activation_sent', is_new=True)
+            return render(request, 'authentication/account_activation_sent.html', {'is_new': True})
         else:
             # Form is not valid.
             pass
@@ -96,10 +96,6 @@ def send_activation(request, user):
         # We're in dev.
         print("Mode dev : mél qui aurait été envoyé :")
         print(message)
-
-def account_activation_sent(request, is_new):
-    is_new_bool = (is_new == True)
-    return render(request, 'authentication/account_activation_sent.html', {'is_new': is_new_bool})
 
 def activate(request, token):
     """Process an activation token.

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -190,7 +190,3 @@ if 'STATIC_ROOT' in dir(settings_local):
 CAPTCHA_NOISE_FUNCTIONS = ('captcha.helpers.noise_dots',)
 CAPTCHA_CHALLENGE_FUNCT = 'captcha.helpers.random_char_challenge'
 CAPTCHA_LENGTH = 5
-
-# Captcha condition for testing in dev mod
-if ROLE == "dev":
-    CAPTCHA_TEST_MODE = True

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -190,3 +190,7 @@ if 'STATIC_ROOT' in dir(settings_local):
 CAPTCHA_NOISE_FUNCTIONS = ('captcha.helpers.noise_dots',)
 CAPTCHA_CHALLENGE_FUNCT = 'captcha.helpers.random_char_challenge'
 CAPTCHA_LENGTH = 5
+
+# Captcha condition for testing in dev mod
+if ROLE == "dev":
+    CAPTCHA_TEST_MODE = True

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -102,11 +102,15 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 PASSWORD_RESET_TIMEOUT_DAYS = 1
 
-EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
-AWS_ACCESS_KEY_ID = settings_local.AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY = settings_local.AWS_SECRET_ACCESS_KEY
-AWS_DEFAULT_REGION = settings_local.AWS_DEFAULT_REGION
-DEFAULT_FROM_EMAIL = settings_local.DEFAULT_FROM_EMAIL
+if ROLE == "dev":
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+else:
+    EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
+    AWS_ACCESS_KEY_ID = settings_local.AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY = settings_local.AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION = settings_local.AWS_DEFAULT_REGION
+    DEFAULT_FROM_EMAIL = settings_local.DEFAULT_FROM_EMAIL
 
 LOGGING = {
     'version': 1,

--- a/transport_nantes/transport_nantes/urls.py
+++ b/transport_nantes/transport_nantes/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from asso_tn.views import MainTransportNantes
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('', MainTransportNantes.as_view(), name='index'),
@@ -34,4 +35,20 @@ urlpatterns = [
     path('tn/', include('asso_tn.urls')),
     path('v/', include('velopolitain.urls')),
     path('vo/', include('velopolitain_observatoire.urls')),
+
+    # Paths below must be here because of django architecture
+    path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(
+        template_name='registration/password_reset_done.html'),
+        name='password_reset_done'),
+    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(
+        template_name='registration/password_reset_confirm.html'
+    ), name='password_reset_confirm'),
+    path('password_reset/', auth_views.PasswordResetView.as_view(
+        template_name='registration/password_reset_form.html',
+        email_template_name='registration/password_reset_email.html',
+        subject_template_name='registration/password_reset_subject.txt'),
+        name='password_reset'),
+    path('reset/done/', auth_views.PasswordResetCompleteView.as_view(
+        template_name='registration/password_reset_complete.html'),
+        name='password_reset_complete'),
 ]


### PR DESCRIPTION
# Add password reset form

* Add templates to authentication/templates/registration
* Add paths to transport_nantes/urls.py instead of authentication/urls.py because paths don't work in authentication/urls.py probably because of django architecture
* Add condition in settings.py for sending of mail to console in dev mode because of Amazon SES doesn't on local environment and make password reset form bug on local machine
* Add password reset link in authentication/login.html

Issue #51