### PR TITLE
Update settings.py to use new url dispatcher

### DIFF
--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -67,7 +67,7 @@ MIDDLEWARE = [
     'asso_tn.middleware.default_context.DefaultContextMiddleware',
 ]
 
-ROOT_URLCONF = os.getenv('ROOT_URLCONF', 'transport_nantes.urls_tn')
+ROOT_URLCONF = os.getenv('ROOT_URLCONF', 'transport_nantes.urls_m')
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Part of #78 
Update settings.py to use the urls_m.py instead of the old urls_tn.py. 