### PR TITLE
Fix test on main page's status

### DIFF
--- a/transport_nantes/topicblog/tests.py
+++ b/transport_nantes/topicblog/tests.py
@@ -1,10 +1,13 @@
 from django.test import TestCase
+from .models import TopicBlogPage
 
 # Create your tests here.
 class SimpleTest(TestCase):
 
     def test_main_page_status_code(self):
         response = self.client.get("/")
-        return self.assertEqual(response.status_code, 200)
-    
-    
+        self.assertEqual(response.status_code, 404)
+
+        TopicBlogPage.objects.create(title="test", slug="test", topic="index", template="topicblog/2020_index.html")
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Part of #78 
Added a test to see if the main page returns 404 while the topicblog's table is empty
Then mocked an entry to the table and verified if the page returned 200. 
