### PR TITLE
Fix responsiveness of navbar for intermediate resolutions.

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -286,3 +286,12 @@ span.centered {
 .footer-social .social > a:hover {
     opacity:0.9;
   }
+@media (min-width: 992px) {
+    .navbar-logo {
+        max-width: 18%;
+    }
+    .navbar-logo-image {
+        width: 100% !important;
+        height: 100%;
+    }
+}

--- a/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
@@ -119,10 +119,10 @@
   <body{% block body_attribs %}{% endblock body_attribs %}>
     {% block body %}
     {% block navbar %}
-       <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
+       <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
 	<!-- Brand -->
-	   <a class="navbar-brand" href="{% url 'index' %}"><img src="{% static 'asso_tn/M-logo_white-32.png' %}" alt="Mobilitains logo"></a>
-	  {% if role == 'dev' %}<span style="background-color: #880000">&nbsp; DEV - DEV - DEV - DEV &nbsp; </span>
+	   <a class="navbar-brand navbar-logo" href="{% url 'index' %}"><img class="navbar-logo-image" src="{% static 'asso_tn/M-logo_white-32.png' %}" alt="Mobilitains logo"></a>
+	  {% if role == 'dev' %} {% comment %} <span style="background-color: #880000">&nbsp; DEV - DEV - DEV - DEV &nbsp; </span> {% endcomment %}
 	  {% elif role == 'beta' %}<span style="background-color: #FF0000">&nbsp; TEST - BETA - TEST - BETA &nbsp;</span>
 	  {% elif not is_production %}<span style="background-color: #FF0000">&nbsp; ce site n'est pas le vrai &nbsp; </span>
 	  {% endif %}
@@ -136,13 +136,13 @@
 		  <div class="collapse navbar-collapse navbars" id="collapse_target1">
 			<ul class="navbar-nav ml-auto">
 				<li class="nav-item">
-					<a class="nav-link pr-3" href="{% url 'topic_blog:view_topic' 'velopolitain' %}">Vélopolitain</a>
+					<a class="nav-link pr-4" href="{% url 'topic_blog:view_topic' 'velopolitain' %}">Vélopolitain</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link pr-3" href="{% url 'topic_blog:view_topic' 'la-grande-mobilite' %}">La Grande Mobilité</a>
+					<a class="nav-link pr-4" href="{% url 'topic_blog:view_topic' 'la-grande-mobilite' %}">La Grande Mobilité</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link pr-3" href="{% url 'topic_blog:view_topic' 'qui-sommes-nous' %}">Qui sommes-nous ?</a>
+					<a class="nav-link pr-5" href="{% url 'topic_blog:view_topic' 'qui-sommes-nous' %}">Qui sommes-nous ?</a>
 				</li>
 
 				<li class="nav-item">{% bouton_don "CONTRIBUER AU PROJET" %}</li>


### PR DESCRIPTION
Menus were breaking in the middle.
Above 992px resolution, the logo is now proportional to the width,
until it collapses at 992px. At this point it gets its normal size back
because the menu are collapsed.

Part of #134