### PR TITLE
Delete extra head and Doctype tags from geoplan.

### DIFF
--- a/transport_nantes/geoplan/views.py
+++ b/transport_nantes/geoplan/views.py
@@ -119,7 +119,12 @@ class MapView(TemplateView):
         # PR is on the way to update folium as of 29/06/21
         # Deleting the extra bootstrap import solves style conflict.
         old_bs_link = "https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"
-        html = html.replace(old_bs_link, "")
+
+        html: str
+        expressions_to_delete = [old_bs_link, '<head>', '</head>', "<!DOCTYPE html>"]
+        for expression in expressions_to_delete:
+            html = html.replace(expression, "")
+
         context["html_map"] = html
         context["map_defn"] = map_definition
 


### PR DESCRIPTION
Although they didn't seem to be problematic for now,
we don't want any sort of issue because of these extra tags
Better safe than sorry.

Closes #193