### PR TITLE
Reload the content upon form validation failure.

### DIFF
--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -131,7 +131,15 @@ class TopicBlogItemEdit(StaffRequiredMixin, FormView):
 
             return render(request, 'topicblog/tb_item_edit.html', context)
 
-        return super().form_valid(form)
+        else:
+            # The form is invalid.  Re-render the form with error
+            # messages.
+            context = self.get_context_data()
+            success = False
+            context['success'] = success
+            context['form'] = form
+
+            return render(request, 'topicblog/tb_item_edit.html', context)
 
 
 def update_template_list(request):


### PR DESCRIPTION
The form used to go blank without much explanation about what failed.

Closes  #249

![image](https://user-images.githubusercontent.com/70256364/138692782-e47e3f27-95a7-4a53-8e9f-99416d25449d.png)

This sort of warning now shows. 