### PR TITLE
Add a button to list of same-slug items in TBv2 creation form.

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
@@ -49,6 +49,23 @@
 	  <!-- Tab panes -->
 	  <div class="tab-content">
 	    <div id="form_admin" class="container tab-pane active"><br>
+			<div id="to_list_button" class="my-2">
+				{% if is_new_item %}
+					<a href="{% url 'topicblog:list_items' %}">
+						<button type="button" class="btn navigation-button">
+								Consulter la liste des contenus
+						</button>
+					</a>
+
+				{% elif is_editing_item %}
+					<a href="{% url 'topicblog:list_items_by_slug' form.slug.value %}">
+						<button type="button" class="btn navigation-button">
+								Consulter la liste des contenus avec le même slug
+						</button>
+					</a>
+				{% endif %}
+			</div>
+
 			{% for field in form %}
 				{% if field.name in form_admin %}
 					<div class="fieldWrapper">

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -70,10 +70,12 @@ class TopicBlogItemEdit(StaffRequiredMixin, FormView):
         if pk_id > 0:
             try:
                 tb_item = get_object_or_404(TopicBlogItem, id=pk_id, slug=slug)
+                context['is_editing_item'] = True
             except ObjectDoesNotExist:
                 raise Http404("Page non trouvée")
         else:
             tb_item = None
+            context['is_new_item'] = True
 
         context["form"] = TopicBlogItemForm(instance=tb_item)
         context["form_admin"] = ["slug", "template", "title", "header_image",


### PR DESCRIPTION
This way users can easily see all the items with the same slug, and can
choose one to edit.

On an existing item, the list is filtered to show only items with the same
slug.



Preview : 
![image](https://user-images.githubusercontent.com/70256364/138707032-ae369561-4c70-4ab8-83fa-462efa35636d.png)
![image](https://user-images.githubusercontent.com/70256364/138707077-dd484b03-be92-4b1d-83d7-4b541291b898.png)
