### PR TITLE
Fix borked dropwdown on edition form.

### DIFF
--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -1,9 +1,12 @@
 from django.forms import ModelForm
-from django.forms.models import ModelChoiceField, ModelMultipleChoiceField
+from django.forms.models import ModelChoiceField
 from .models import TopicBlogItem, TopicBlogTemplate
 
 
 class TopicBlogItemForm(ModelForm):
+    """
+    Generates a form to create and edit TopicsBlogItem objects.
+    """
 
     class Meta:
         model = TopicBlogItem
@@ -12,8 +15,9 @@ class TopicBlogItemForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['template'] = ModelChoiceField(
-            queryset=TopicBlogTemplate.objects.none())
+        if self.fields["content_type"] is None:
+            self.fields['template'] = ModelChoiceField(
+                queryset=TopicBlogTemplate.objects.none())
 
         # self.data is the POST data
         if 'template' in self.data:

--- a/transport_nantes/topicblog/static/topicblog/update_template_list.js
+++ b/transport_nantes/topicblog/static/topicblog/update_template_list.js
@@ -28,7 +28,7 @@ async function update_template_list() {
 }
 
 function select_first_item() {
-  $('#id_template option[value="1"]').attr('selected', 'selected');
+  $("#id_template")[0].selectedIndex = 1;
 }
 
 $("#id_content_type").change(async () => {

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -32,7 +32,6 @@ class TopicBlogItemEdit(StaffRequiredMixin, FormView):
     # we'll just present one big page with all the sections joined.
 
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
         # In FormView, we must use the self.kwargs to retrieve the URL
         # parameters. This stems from the View class that transfers
         # the URL parameters to the View instance and assigns kwargs
@@ -43,12 +42,15 @@ class TopicBlogItemEdit(StaffRequiredMixin, FormView):
         if pk_id > 0:
             try:
                 tb_item = get_object_or_404(TopicBlogItem, id=pk_id, slug=slug)
+                kwargs["form"] = TopicBlogItemForm(instance=tb_item)
+                context = super().get_context_data(**kwargs)
             except ObjectDoesNotExist:
                 raise Http404("Page non trouvée")
         else:
             tb_item = None
+            # context["form"] is set by the FormView
+            context = super().get_context_data(**kwargs)
 
-        context["form"] = TopicBlogItemForm(instance=tb_item)
         context["form_admin"] = ["slug", "template", "title", "header_image",
                                  "header_title", "header_description",
                                  "header_slug", "content_type"]


### PR DESCRIPTION
Splitting the form into two classes avoid the former default behavior of
the "template" field to be empty when the form is loaded.

Closes #250 