### PR TITLE
Add a button to delete previously loaded image in TBv2 form

### DIFF
--- a/transport_nantes/topicblog/static/topicblog/clear_file_inputs.js
+++ b/transport_nantes/topicblog/static/topicblog/clear_file_inputs.js
@@ -1,0 +1,17 @@
+function reset_html(id) {
+    $('#' + id).html($('#' + id).html());
+    return false;
+}
+
+$(document).ready(function () {
+
+    var file_input_index = 0;
+    $('input[type=file]').each(function () {
+        file_input_index++;
+        $(this).wrap('<div id="file_input_container_' + file_input_index + '"></div>');
+        $(this).after('<u><a href="#" '
+        + 'onclick="reset_html(\'file_input_container_' + file_input_index + '\');"'
+        + 'class="small text-dark my-1">' + 'Supprimer l\'image' + '</a></u>');
+    });
+
+});

--- a/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
@@ -19,6 +19,7 @@
 {% block app_content %}
 <script src="{% static 'topicblog/update_template_list.js' %}" defer></script>
 <script src="{% static 'topicblog/clean_slug_field.js' %}" defer></script>
+<script src="{% static 'topicblog/clear_file_inputs.js' %}" defer></script>
 
 {% if success %}
 <div class="alert alert-success center flex-column">


### PR DESCRIPTION
Previously, once an image had been chosen, user couldn't decide
they didn't want to use a picture.

closes #260 

V1
![image](https://user-images.githubusercontent.com/70256364/139035276-967fe3d5-a248-4b5c-8ad1-ed93a85f52d8.png)

V2 (Current) 
![image](https://user-images.githubusercontent.com/70256364/139043452-929fd197-ef36-4085-a98f-bed7864f2838.png)
