### PR TITLE
Add @StaffRequired decorator to secure Ajax endpoints

### DIFF
--- a/transport_nantes/asso_tn/utils.py
+++ b/transport_nantes/asso_tn/utils.py
@@ -1,6 +1,8 @@
 import datetime
+from functools import wraps
 
 from django.conf import settings
+from django.http.response import HttpResponseForbidden
 from django.utils.crypto import salted_hmac
 from django.utils.crypto import secrets
 from django.utils.http import base36_to_int, int_to_base36
@@ -51,3 +53,15 @@ class StaffRequiredMixin(LoginRequiredMixin, UserPassesTestMixin):
 
     def test_func(self):
         return self.request.user.is_staff
+
+
+def StaffRequired(func):
+    """Decorator that checks for Staff status to access the function"""
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        if request.user.is_staff:
+            return func(request, *args, **kwargs)
+        else:
+            return HttpResponseForbidden("""Vous n'avez pas l'autorisation
+            d'accéder à cette page.""")
+    return wrapper

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -6,8 +6,8 @@ from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 from django.core.exceptions import ObjectDoesNotExist
 
-from asso_tn.utils import StaffRequiredMixin
-from .models import TopicBlogPage, TopicBlogItem, TopicBlogTemplate
+from asso_tn.utils import StaffRequiredMixin, StaffRequired
+from .models import TopicBlogItem, TopicBlogTemplate
 from .forms import TopicBlogItemForm
 
 
@@ -113,11 +113,16 @@ class TopicBlogItemEdit(StaffRequiredMixin, FormView):
             return render(request, 'topicblog/tb_item_edit.html', context)
 
 
+@StaffRequired
 def update_template_list(request):
+    """
+    Uses a content type passed through Ajax to render
+    a dropdown list of templates associated with this
+    content type for the user to choose from.
+    """
     content_type = request.GET.get('content_type')
     templates = TopicBlogTemplate.objects.filter(
         content_type=content_type)
-    print("Templates value : ", templates)
     return render(request, 'topicblog/template_dropdown.html',
                   {'templates': templates})
 


### PR DESCRIPTION
This decorator is used to secure Ajax endpoints.

With this decorator, only staff users will be able to access these
endpoints.

Closes #268