### PR TITLE
Add a message under the Slug Field in TBv2

### DIFF
--- a/transport_nantes/topicblog/static/topicblog/same_slug_warning.js
+++ b/transport_nantes/topicblog/static/topicblog/same_slug_warning.js
@@ -1,0 +1,53 @@
+// Calls server to get a list of all slugs and
+// how many of each slug there are.
+async function get_slug_dict() {
+    data = await $.ajax({
+        url: '/tb/ajax/get-slug-dict/',
+    })
+    return data;
+}
+
+// Get an url from the server that leads to a list
+// of all items with the given slug
+async function get_url_list(slug) {
+    data = await $.ajax({
+        url: '/tb/ajax/get-url-list/',
+        data: {
+            slug: slug,
+        },
+    })
+    return data;
+}
+
+$(document).ready(async function () {
+
+    var slug_dict = await get_slug_dict();
+
+    // Create a div in wich we will put the warning
+    $("input[id='id_slug']").after('<div class="small" id="slug_warning"></div>');
+    // On each change, we check the value of the slug.
+    // If it matches with an item of the list of existing slugs, 
+    // we display a message with a link to the list of items with the same slug.
+    $("input[id='id_slug']").on('input', async function () {
+        var slug = $(this).val();
+        if (slug in slug_dict){
+            var url_list = await get_url_list(slug);
+
+            var message = "<p>Ce slug est partagé par <u><a"
+            + " href='" + url_list["url"]+ "'>"
+            + slug_dict[slug]
+
+            if (slug_dict[slug] > 1){
+                message += " items."
+            }
+            else{
+                message += " item."
+            }
+
+            $("#slug_warning").html(message + "</a></u></p>");
+
+        } else {
+            $("#slug_warning").html("");
+        }
+    });
+});

--- a/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
@@ -20,6 +20,7 @@
 <script src="{% static 'topicblog/update_template_list.js' %}" defer></script>
 <script src="{% static 'topicblog/clean_slug_field.js' %}" defer></script>
 <script src="{% static 'topicblog/clear_file_inputs.js' %}" defer></script>
+<script src="{% static 'topicblog/same_slug_warning.js' %}" defer></script>
 
 {% if success %}
 <div class="alert alert-success center flex-column">

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 # from django.views.generic.base import RedirectView
-from .views import TopicBlogItemEdit, TopicBlogItemView, TopicBlogItemViewOne, TopicBlogItemList
-from .views import TopicBlogItemEdit, update_template_list
-from transport_nantes.settings import ROLE
+from .views import (TopicBlogItemEdit, TopicBlogItemView, TopicBlogItemViewOne,
+                    TopicBlogItemList)
+from .views import (update_template_list, get_slug_dict, get_url_list)
+# from transport_nantes.settings import ROLE
 
 app_name = 'topic_blog'
 urlpatterns = [
@@ -29,8 +30,13 @@ urlpatterns = [
          name='list_items'),
     path('admin/list/<slug:item_slug>/', TopicBlogItemList.as_view(),
          name='list_items_by_slug'),
+
     path('ajax/update-template-list/', update_template_list,
-         name="update_template_list")
+         name="update_template_list"),
+    path('ajax/get-slug-dict/', get_slug_dict,
+         name="get_slug_dict"),
+    path('ajax/get-url-list/', get_url_list,
+         name="get_url_list"),
 ]
 
 # Need topic creation.

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -1,10 +1,15 @@
+from collections import Counter
+
 from django.http import Http404
+from django.http.response import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.contrib.auth.models import User
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 from django.core.exceptions import ObjectDoesNotExist
+from django.urls import reverse
+
 
 from asso_tn.utils import StaffRequiredMixin, StaffRequired
 from .models import TopicBlogItem, TopicBlogTemplate
@@ -210,3 +215,21 @@ class TopicBlogItemList(StaffRequiredMixin, ListView):
             item_slug = self.kwargs['item_slug']
             qs = qs.filter(slug=item_slug)
         return qs
+
+
+@StaffRequired
+def get_slug_dict(request):
+    """Return a list of all existing slugs"""
+    qs = TopicBlogItem.objects.order_by('slug').values('slug')
+    dict_of_slugs = Counter([item['slug'] for item in qs])
+    return JsonResponse(dict_of_slugs, safe=False)
+
+
+@StaffRequired
+def get_url_list(request):
+    """Return an url directing to a list of items
+    given a slug.
+    """
+    slug = request.GET.get('slug')
+    url = reverse("topicblog:list_items_by_slug", args=[slug])
+    return JsonResponse({'url': url})


### PR DESCRIPTION
Now OK to merge

This message informs the user if the slug its entering is already
in use.

The goal is to not use slugs that have already been used unknowingly.

Closes #246

![image](https://user-images.githubusercontent.com/70256364/140032571-d019ed6a-24b2-4a64-ae7a-4aef902b85a5.png)

![image](https://user-images.githubusercontent.com/70256364/140032614-43064926-fd06-4ee4-822d-434cc9085d80.png)

Ajax endpoints have been secured with @StaffRequired decorator (see #270)

```cmd
benja@Benja-desktop:~/Documents/GitHub/tn_web/transport_nantes$ curl -I localhost:8000/tb/ajax/get-slug-dict/
HTTP/1.1 403 Forbidden
Date: Wed, 03 Nov 2021 13:20:58 GMT
Server: WSGIServer/0.2 CPython/3.8.10
Content-Type: text/html; charset=utf-8
X-Frame-Options: DENY
Content-Length: 68
Vary: Cookie
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Set-Cookie:  sessionid=un4xiufkkbnb4kuy5za09wzb4f7sugfr; expires=Mon, 02 May 2022 13:20:58 GMT; HttpOnly; Max-Age=15552000; Path=/; SameSite=Lax

benja@Benja-desktop:~/Documents/GitHub/tn_web/transport_nantes$ curl -I localhost:8000/tb/ajax/get-url-list/
HTTP/1.1 403 Forbidden
Date: Wed, 03 Nov 2021 13:21:14 GMT
Server: WSGIServer/0.2 CPython/3.8.10
Content-Type: text/html; charset=utf-8
X-Frame-Options: DENY
Content-Length: 68
Vary: Cookie
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Set-Cookie:  sessionid=nu2bic1q9yxz60mu8uc3i2rgno01byt0; expires=Mon, 02 May 2022 13:21:14 GMT; HttpOnly; Max-Age=15552000; Path=/; SameSite=Lax
```