### PR TITLE
Update tbv2 tests

### DIFF
--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -11,7 +11,7 @@ class TopicBlogItemForm(ModelForm):
     class Meta:
         model = TopicBlogItem
         # Admins can still edit those values
-        exclude = ('item_sort_key', 'servable', 'user', 'published',
+        exclude = ('item_sort_key', 'servable', 'user',
                    'publication_date')
 
     def __init__(self, *args, **kwargs):

--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -206,7 +206,6 @@ class TopicBlogTemplate(models.Model):
     #
     #   item_sort_key
     #   servable
-    #   published
     #   publication_date
     #   template
     #   user

--- a/transport_nantes/topicblog/tests_auth_users.py
+++ b/transport_nantes/topicblog/tests_auth_users.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from django.test import TestCase
 from .models import (TopicBlogPage, TopicBlogItem, TopicBlogTemplate,
                      TopicBlogContentType)
@@ -26,7 +28,7 @@ class Test(TestCase):
             slug="index",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -55,7 +57,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -65,7 +67,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="",
             item_sort_key=0,
             servable=False,
-            published=False,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -75,7 +77,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=3,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,

--- a/transport_nantes/topicblog/tests_staff_users.py
+++ b/transport_nantes/topicblog/tests_staff_users.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from django.test import TestCase
 from .models import (TopicBlogPage, TopicBlogItem, TopicBlogTemplate,
                      TopicBlogContentType)
@@ -26,7 +28,7 @@ class Test(TestCase):
             slug="index",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -56,7 +58,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -66,7 +68,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="",
             item_sort_key=0,
             servable=False,
-            published=False,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -76,7 +78,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=3,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,

--- a/transport_nantes/topicblog/tests_unauth_users.py
+++ b/transport_nantes/topicblog/tests_unauth_users.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from django.test import TestCase
 from .models import (TopicBlogPage, TopicBlogItem, TopicBlogTemplate,
                      TopicBlogContentType)
@@ -27,7 +29,7 @@ class SimpleTest(TestCase):
             slug="index",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -55,7 +57,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=1,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -65,7 +67,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="",
             item_sort_key=0,
             servable=False,
-            published=False,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,
@@ -75,7 +77,7 @@ class TBIEditStatusCodeTest(TestCase):
             slug="test-slug",
             item_sort_key=3,
             servable=True,
-            published=True,
+            publication_date=datetime.now(timezone.utc),
             user=self.user,
             content_type=self.content_type,
             template=self.template,


### PR DESCRIPTION
Update tests to integrate the change about published attribute being removed for the publication_date attribute.

These tests do not check yet the hypothesis where we try to serve an item not published yet, as all items created in the tests are published. 

However it gives us reassurance that nothing broke regarding already published items, which is a plus. 

Part of the #293  issue.