### PR TITLE
Revert the suggestion feature in TBv2

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
@@ -21,7 +21,15 @@
 <script src="{% static 'topicblog/clean_slug_field.js' %}" defer></script>
 <script src="{% static 'topicblog/clear_file_inputs.js' %}" defer></script>
 <script src="{% static 'topicblog/same_slug_warning.js' %}" defer></script>
-<script src="{% static 'topicblog/get_slug_suggestions.js' %}" defer></script>
+{% comment "about json_script" %}
+The context variable slug_fields is a Python list passed into the html document
+in a script tag under the provided css ID thanks to the |json_script filter.
+See documentation : 
+https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#json-script
+It can be then parsed into a Javascript array. Using it spares an Ajax call.
+This particular instance is used to get the ids of the slug fields in the form.
+It is retrieved inside clean_slug_field.js
+{% endcomment %}
 {{slug_fields|json_script:"slug_fields"}}
 
 {% if success %}
@@ -56,22 +64,6 @@
 	    <div id="form_admin" class="container tab-pane active"><br>
 			{% for field in form %}
 				{% if field.name in form_admin %}
-					{% if field.name == "slug" %}
-					{% comment %}
-					The slug field is a special case : because |as_crispy doesn't render
-					the input field with a datalist, we manually render it here.
-					The classes used are the same Crispy uses, for now.
-					The datalist is dynamically generated, and the list of suggestions
-					come from an AJAX call to the server. 
-					{% endcomment %}
-						<div class="fieldWrapper">
-							<div id="div_id_slug" class="form-group">
-								<label for="id_slug" class="">Slug</label>
-								<input list="slug_list" type="text" id="id_slug" class="textinput textInput form-control">
-								<datalist id="slug_list"></datalist>
-							</div>
-						</div>
-					{% else %}
 						<div class="fieldWrapper">
 							{{ field.errors }}
 							{{ field|as_crispy_field }}
@@ -79,7 +71,6 @@
 								<p class="help">{{ field.help_text|safe }}</p>
 							{% endif %}{% endcomment %}
 						</div>
-					{% endif %}
 				{% endif %}
 			{% endfor %}
 	    </div>


### PR DESCRIPTION
It introduced a breaking bug that made the slug field not save.

the suggestion feature is a nice to have one, but I'd say it's not exactly a priority either, as we have a warning if we're using the same slug as an existing article. 

Wdyt ?  

Closes  #306