### PR TITLE
Fix images not saving between copies of a TBItem

### DIFF
--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -528,6 +528,18 @@ class TopicBlogItem(models.Model):
 
         return slug_fields
 
+    def get_image_fields(self) -> list:
+        """
+        Return the names of fields that are Django ImageFields
+        """
+        all_fields = self._meta.get_fields()
+        image_fields = list()
+        for field in all_fields:
+            if isinstance(field, models.ImageField):
+                image_fields.append(field.name)
+
+        return image_fields
+
     def get_servable_status(self):
         """Return True if page is user visible, False otherwise."""
         if not self.servable:


### PR DESCRIPTION
Images are lost if we save a copy for modification in our current build.
This PR intends to fix this behavior by copying the originally edited item's images and transferring them to the next copy. 

Part of #322