### PR TITLE
Captcha error 384

### DIFF
--- a/transport_nantes/mailing_list/forms.py
+++ b/transport_nantes/mailing_list/forms.py
@@ -1,9 +1,9 @@
 from django import forms
 from django.contrib.auth.models import User
-from django.forms import Form, ModelForm
+from django.forms import ModelForm
 from captcha.fields import CaptchaField
-from authentication.models import Profile
 from .models import MailingList
+
 
 class MailingListMMCF(forms.ModelMultipleChoiceField):
     """A custom form that gives us pretty mailing list labels in
@@ -18,6 +18,7 @@ class MailingListMMCF(forms.ModelMultipleChoiceField):
     def label_from_instance(self, member):
         return '{name}'.format(name=member.mailing_list_name)
 
+
 class MailingListSignupForm(ModelForm):
     captcha = CaptchaField(
         label="Je suis humain",
@@ -30,9 +31,11 @@ class MailingListSignupForm(ModelForm):
     code_postal = forms.CharField(
         max_length=80,
         required=False,
-        label="Code postal", help_text='Nous aide à vous apporter des actualités')
+        label="Code postal",
+        help_text='Nous aide à vous apporter des actualités')
     newsletters = MailingListMMCF(
-        queryset=MailingList.objects.filter(list_active=True, is_petition=False),
+        queryset=MailingList.objects.filter(list_active=True,
+                                            is_petition=False),
         widget=forms.CheckboxSelectMultiple({'class': 'no-bullet-list'}),
         label="Je m’inscris :")
 
@@ -90,7 +93,7 @@ class QuickPetitionSignupForm(ModelForm):
         error_messages=dict(invalid="captcha incorrect, veuillez réessayer"))
     petition_name = forms.CharField(
         max_length=80,
-        required=False,#True
+        required=False,  # True
         widget=forms.HiddenInput())
 
     class Meta:

--- a/transport_nantes/mailing_list/forms.py
+++ b/transport_nantes/mailing_list/forms.py
@@ -52,12 +52,14 @@ class MailingListSignupForm(ModelForm):
             'email': "*",
         }
 
+
 # Like MailingListSignupForm, but only requests email.
 class QuickMailingListSignupForm(ModelForm):
     captcha = CaptchaField(
         label="Je suis humain",
         help_text="* disponibilité réservée aux humains",
-        error_messages=dict(invalid="captcha incorrect, veuillez réessayer"))
+        error_messages=dict(invalid="captcha incorrect, veuillez réessayer"),
+        required=True)
     mailinglist = forms.CharField(
         max_length=100,
         required=True,
@@ -70,6 +72,16 @@ class QuickMailingListSignupForm(ModelForm):
         labels = {
             'email': "Adresse mél",
         }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        email = cleaned_data.get('email')
+
+        if email == "":
+            self.add_error('email', "Vous devez entrer une adresse mél")
+
+        return cleaned_data
+
 
 class QuickPetitionSignupForm(ModelForm):
     captcha = CaptchaField(

--- a/transport_nantes/mailing_list/templates/mailing_list/quick_signup_m.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/quick_signup_m.html
@@ -20,6 +20,9 @@
 <div class="container pt-5">
     <div class="row">
 	<div class="col-md-12">
+		{% if form.errors %}
+			<p class="text-danger">{{ form.errors }}</p>
+		{% endif %}
 	    <p>Vous y êtes presque&nbsp!</p>
 
 	    <form method="post">{% csrf_token %}

--- a/transport_nantes/mailing_list/views.py
+++ b/transport_nantes/mailing_list/views.py
@@ -110,6 +110,7 @@ class QuickMailingListSignup(FormView):
         then display the correct thing.  I think.
 
         """
+        form["email"].initial = self.request.POST["email"]
         return render(self.request, self.template_name, {'form': form})
 
     def form_valid(self, form):

--- a/transport_nantes/mailing_list/views.py
+++ b/transport_nantes/mailing_list/views.py
@@ -10,11 +10,13 @@ from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
 from asso_tn.views import AssoView
-from .forms import MailingListSignupForm, QuickMailingListSignupForm, QuickPetitionSignupForm
+from .forms import (MailingListSignupForm, QuickMailingListSignupForm,
+                    QuickPetitionSignupForm)
 from .models import MailingList, MailingListEvent, Petition
 from .events import user_subscribe_count, subscriber_count
 
 logger = logging.getLogger("django")
+
 
 class MailingListSignup(FormView):
     template_name = 'mailing_list/signup_m.html'


### PR DESCRIPTION
When the user got something wrong (either missing email or invalid
captcha), no error was displayed, which could lead to confusion.

Minor improvement : The mail entered in the invalid form is pre-filled
in the new form.

Closes #384

Aside, some light PEP8 formatting, in a separate commit. 