### PR TITLE
Make mailinglist template tag context sensitive

### DIFF
--- a/transport_nantes/topicblog/templatetags/markdown.py
+++ b/transport_nantes/topicblog/templatetags/markdown.py
@@ -3,9 +3,9 @@ from django.utils.html import escape, mark_safe
 from markdown2 import markdown
 
 from topicblog.tn_links import TNLinkParser
-from django import template
 
 register = template.Library()
+
 
 @register.simple_tag(takes_context=True, name="tn_markdown")
 def tn_markdown(context, value):
@@ -18,5 +18,5 @@ def tn_markdown(context, value):
 
       {% tn_markdown md_text_variable %}
     """
-    parser = TNLinkParser(verbose=False)
+    parser = TNLinkParser(context, verbose=False)
     return mark_safe(markdown(parser.transform(escape(value))))

--- a/transport_nantes/topicblog/test_tn_links.py
+++ b/transport_nantes/topicblog/test_tn_links.py
@@ -9,7 +9,7 @@ from .tn_links import TNLinkParser, render_inclusion_tag_to_html
 
 class TnLinkParserTest(TestCase):
     def setUp(self):
-        self.parser = TNLinkParser(verbose=False)
+        self.parser = TNLinkParser({}, verbose=False)
 
     def test_broken_links(self):
         self.assertEqual(self.parser.transform('[['), '[[')
@@ -71,7 +71,7 @@ class TnLinkParserTest(TestCase):
         html = 'dog ' + don.external_url(url, label) + ' cat'
         self.assertEqual(self.parser.transform(markdown), html)
 
-        self.parser = TNLinkParser(verbose=False)
+        self.parser = TNLinkParser({}, verbose=False)
         pdll = 'Pays de la Loire'
         pdll_url = 'https://dog/cat/horse'
         markdown = '[[externe:{label}]](({url}))'.format(label=pdll, url=pdll_url)
@@ -89,7 +89,7 @@ class TnLinkParserTest(TestCase):
         html = 'dog ' + don.external_url_button(url, label) + ' cat'
         self.assertEqual(self.parser.transform(markdown), html)
 
-        self.parser = TNLinkParser(verbose=False)
+        self.parser = TNLinkParser({}, verbose=False)
         pdll = 'Pays de la Loire'
         pdll_url = 'https://dog/cat/horse'
         markdown = '[[EXTERNE:{label}]](({url}))'.format(label=pdll, url=pdll_url)


### PR DESCRIPTION
The HTML code produced by this tag is now aware of the general context
provided by the context processor.
This means we can now check the user's login status for example.

Closes #391