### PR TITLE
Rename tab in TBI and clarify buttons

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_item_edit.html
@@ -49,7 +49,7 @@ It is retrieved inside clean_slug_field.js
 	      <a class="nav-link" data-toggle="tab" href="#form_social">Social</a>
 	    </li>
 		<li class="nav-item">
-	      <a class="nav-link" data-toggle="tab" href="#form_etc">Autres</a>
+	      <a class="nav-link" data-toggle="tab" href="#form_notes">Notes</a>
 	    </li>
 	  </ul>
 
@@ -107,9 +107,9 @@ It is retrieved inside clean_slug_field.js
 				{% endif %}
 			{% endfor %}
 	    </div>
-		<div id="form_etc" class="container tab-pane fade"><br>
+		<div id="form_notes" class="container tab-pane fade"><br>
 			{% for field in form %}
-				{% if field.name in form_etc %}
+				{% if field.name in form_notes %}
 					<div class="fieldWrapper">
 						{{ field.errors }}
 						{{ field|as_crispy_field }}
@@ -122,8 +122,9 @@ It is retrieved inside clean_slug_field.js
 	    </div>
 	  </div>
 		<div id="button-container" class="d-flex container justify-content-around">
-			<input class="mt-3" type="button" value="Annuler" onclick="window.location.href=window.location.href">
-			<input class="mt-3" type="submit" value="Sauvegarder" name="sauvegarder">
+			<input class="btn navigation-button mt-3" type="button" value="Réinitialiser" onclick="window.location.href=window.location.href">
+			<a href="{% url 'topicblog:list_items' %}" class="btn navigation-button mt-3">Retour à la liste</a>		
+			<input class="btn navigation-button mt-3" type="submit" value="Sauvegarder" name="sauvegarder">
 		</div>
 	</div>
     </form>

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -282,7 +282,7 @@ class TopicBlogItemEdit(TopicBlogBaseEdit):
         context["form_social"] = ["social_description", "twitter_title",
                                   "twitter_description", "twitter_image",
                                   "og_title", "og_description", "og_image"]
-        context["form_etc"] = ["author_notes"]
+        context["form_notes"] = ["author_notes"]
 
         context["slug_fields"] = tb_item.get_slug_fields()
 


### PR DESCRIPTION
The cancel button could be misunderstood, changing the wording
clears that confusion.
Added a button to return to the list of articles, which is the
function one could expect from the cancel button.

Part of #442