### PR TITLE
Fix reference before assignement on form_valid 

### DIFF
--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -63,6 +63,8 @@ class TopicBlogBaseEdit(StaffRequiredMixin, FormView):
         if pkid > 0:
             tb_existing = self.model.objects.get(id=pkid)
             tb_object.first_publication_date = tb_existing.first_publication_date
+        else:
+            tb_existing = None
 
         if hasattr(self, "form_post_process"):
             self.form_post_process(tb_object, tb_existing, form)

--- a/transport_nantes/transport_nantes/urls.py
+++ b/transport_nantes/transport_nantes/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls.static import static
 from transport_nantes.settings import ROLE
 
 urlpatterns = [
-    path('', TopicBlogItemView.as_view(), {'the_slug': 'index'},
+    path('', TopicBlogItemView.as_view(), {'the_slug': 'ligne-johanna-rolland-2021'},
          name='index'),
     path('admin/', admin.site.urls),
     path('auth/', include('authentication.urls')),


### PR DESCRIPTION
The form_post_process only makes sense for already existing objects,
moving it to a condition where we know we're editing an existing object
prevents us to referencing to one when there is none.

This commit would be cherry picked once we go back to master as the deployed branch. 