### PR TITLE
Create Temporary view to add missing records

### DIFF
--- a/transport_nantes/stripe_app/admin.py
+++ b/transport_nantes/stripe_app/admin.py
@@ -12,6 +12,10 @@ class DonationAdmin(admin.ModelAdmin):
     def has_change_permission(self, request, obj=None):
         """Makes read only all fields of the model."""
         return False
+    readonly_fields = ("timestamp",)
+
+    class Meta:
+        list_display = [field.name for field in Donation._meta.get_fields()]
 
 
 admin.site.register(TrackingProgression, TrackingProgressionAdmin)

--- a/transport_nantes/stripe_app/urls.py
+++ b/transport_nantes/stripe_app/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import (QuickDonationView, StripeView, SuccessView, get_public_key,
+from .views import (QuickDonationView, StripeView, SuccessView,
+                    TempCreateMissingRecords, get_public_key,
                     create_checkout_session, tracking_progression,
                     stripe_webhook)
 
@@ -14,4 +15,6 @@ urlpatterns = [
     path('success/', SuccessView.as_view(), name="stripe_success"),
     path('tracking/', tracking_progression),
     path('webhook/', stripe_webhook, name="webhook"),
+    path('migrate-my-user/<str:stripe_customer_id>/<str:username>/',
+         TempCreateMissingRecords.as_view(), name="create_missing_records"),
 ]


### PR DESCRIPTION
Some records were missing because of a hole in the Stripe code.
This view will fire once and 500 if refreshed, effectively creating
the missing records only once.

It's stripped of identifying information on purpose.

It's been tested locally
![stripe_fix](https://user-images.githubusercontent.com/70256364/154287651-feec38c9-2ba5-4b3e-860f-47463460c8f0.gif)

We need to give the django username and the stripe_customer_id in the URL, so no information shows in this code.

This view will only work once and on a user with only one existing record of Donation, otherwise it will fail purposefully.   