### PR TITLE
Make email template 419

### DIFF
--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -5,7 +5,6 @@ from django.utils.crypto import get_random_string
 from django.views.generic.edit import FormView
 from django.core.mail import send_mail
 from django.contrib import auth
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
 from django.shortcuts import render, redirect
@@ -13,6 +12,7 @@ from django.template.loader import render_to_string
 from django.contrib.auth.views import LogoutView
 from django.conf import settings
 from django.urls import reverse
+from django.utils.html import strip_tags
 from django.views.generic.base import TemplateView
 
 from authentication.forms import (EmailLoginForm, PasswordLoginForm,
@@ -132,7 +132,11 @@ def send_activation(request, email, remember_me):
 
     """
     subject = 'sujet'
-    message = render_to_string(
+    # Emails can have a HTML version and a plain text alternative.
+    # https://docs.djangoproject.com/en/3.2/topics/email/#send-mail
+    # You can pass html to the send_mail function through the
+    # html_message argument.
+    html_message = render_to_string(
         'authentication/account_activation_email.html',
         {  # request.build_absolute_uri(),
             'scheme': request.scheme,
@@ -140,14 +144,15 @@ def send_activation(request, email, remember_me):
             'token': make_timed_token(email, 20),
             'remember_me': remember_me,
         })
-
+    plain_text_message = strip_tags(html_message)
     if hasattr(settings, 'ROLE') and settings.ROLE in ['beta', 'production']:
         try:
             send_mail(
                 subject,
-                message,
+                plain_text_message,
                 settings.DEFAULT_FROM_EMAIL,
                 [email],
+                html_message=html_message,
                 fail_silently=False)
         except Exception as e:
             logger.error(f"Error while sending mail to {email} : {e}")
@@ -155,7 +160,7 @@ def send_activation(request, email, remember_me):
     elif os.getenv('TEST_MODE', "0") == "0":
         # Only print this in dev mode, which is the only time
         # we'd care.
-        print(f"Sent message : \n{message}")
+        print(f"Sent message : \n{plain_text_message}")
 
 
 class ActivationLoginView(TemplateView):

--- a/transport_nantes/mailing_list/models.py
+++ b/transport_nantes/mailing_list/models.py
@@ -1,14 +1,12 @@
 from django.db import models
 from django.contrib.auth.models import User
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 import django.utils.timezone
-import uuid
 
 # This application might have been called newsletter.  Think of this
 # as about newsletters, not about the lists, in the sense that this is
 # an application that is designed for keeping in touch with lists of
 # people, currently by email.
+
 
 class MailingList(models.Model):
     """Represent things a mailing list.
@@ -45,6 +43,7 @@ class MailingList(models.Model):
             name=self.mailing_list_name,
             token=self.mailing_list_token,
             freq=self.contact_frequency_weeks)
+
 
 class Petition(models.Model):
     """Parameters of a petition.
@@ -99,6 +98,7 @@ class Petition(models.Model):
             sl=self.slug,
             list_name=self.mailing_list.mailing_list_name)
 
+
 class MailingListEvent(models.Model):
     """Events on mailing lists.
 
@@ -134,4 +134,3 @@ class MailingListEvent(models.Model):
 
 # We'll need to make sure we have an automatic unsubscribe pathway
 # with link in mails.
-

--- a/transport_nantes/topicblog/templates/topicblog/tbemails/base_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/tbemails/base_email.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="https://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="x-apple-disable-message-reformatting">
+    <title></title>
+    {% comment %}
+        Some CSS and PNG sizing resets for Microsoft Outlook on Windows
+        hidden inside conditional comments (the <!--[if mso]> bits)
+        src : https://webdesign.tutsplus.com/articles/creating-a-simple-responsive-html-email--webdesign-12978
+    {% endcomment %}
+    <!--[if mso]>
+    <style>
+        table {border-collapse:collapse;border-spacing:0;border:none;margin:0;}
+        div, td {padding:0;}
+        div {margin:0 !important;}
+    </style>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+    <style>
+        table, td, div, h1, p {
+            font-family: Arial, sans-serif;
+        }
+        @media screen and (max-width: 530px) {
+            .unsub {
+                display: block;
+                padding: 8px;
+                margin-top: 14px;
+                border-radius: 6px;
+                background-color: #555555;
+                text-decoration: none !important;
+                font-weight: bold;
+            }
+            .col-lge {
+                max-width: 100% !important;
+            }
+        }
+        @media screen and (min-width: 531px) {
+            .col-sml {
+                max-width: 27% !important;
+            }
+            .col-lge {
+                max-width: 73% !important;
+            }
+        }
+        a:link.donation-button {
+            color: white;
+            font-weight: 600;
+            background-color: #5BC2E7;
+            border-radius: 0;
+        }
+        a:visited.donation-button {
+            color: white;
+        }
+        a:hover.donation-button {
+            color: white;
+        }
+        .donation-button {
+            background-color: #5BC2E7;
+            color:white;
+            font-weight: 600;
+        }
+        .btn.donation-button:hover {
+            color:white;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 400;
+            color: #212529;
+            text-align: center;
+            vertical-align: middle;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            background-color: transparent;
+            border: 1px solid transparent;
+            padding: .375rem .75rem;
+            font-size: 1rem;
+            line-height: 1.5;
+            border-radius: .25rem;
+            transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+            text-decoration: none;
+        }
+    </style>
+    <script src="https://kit.fontawesome.com/46b82563d9.js" crossorigin="anonymous"></script>
+</head>
+<body style="margin:0;padding:0;word-spacing:normal;background-color:#939297;">
+    <div role="article" aria-roledescription="email" lang="fr"
+    style="text-size-adjust:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;background-color:#939297;">
+        {% comment %}
+        This scaffold is necessary so that our email will be centered across all email clients.
+        We create a 100% wide table, and then set the border and border-spacing to zero.
+        Then we create a row and table cell with no padding which has align="center" set so that its contents will be centered.
+        {% endcomment %}
+        <table role="presentation" style="width:100%;border:none;border-spacing:0;">
+            <tr>
+                <td align="center" style="padding:0;">
+                {% comment %}
+                Before adding our main content container, we need to set up a Ghost Table:
+                a rigid table with a fixed width that only renders in Outlook because it’s hidden
+                inside some special Outlook-only conditional comments. We need to do this because
+                our main container is going to use the CSS max-width property, and not all versions
+                of Outlook for Windows support it. Without max-width support, the main container
+                would explode to full-width when viewed in Outlook for Windows, so we need to contain it.
+                {% endcomment %}
+                    <!--[if mso]>
+                        <table role="presentation" align="center" style="width:600px;">
+                        <tr>
+                        <td>
+                    <![endif]-->
+                        {% block email_content %}{% endblock email_content %}
+                    <!--[if mso]>
+                        </td>
+                        </tr>
+                        </table>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/transport_nantes/topicblog/templates/topicblog/tbemails/email.html
+++ b/transport_nantes/topicblog/templates/topicblog/tbemails/email.html
@@ -1,0 +1,58 @@
+{% extends 'topicblog/tbemails/base_email.html' %}
+{% load static %}
+{% load email_tags %}
+
+{% block email_content %}
+
+{% comment %} This table is the main container{% endcomment %}
+<table role="presentation"
+style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
+    <tr>
+        {% comment "Logo" %}This row handles the logo display{% endcomment %}
+        <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">
+            <a href="https://www.mobilitains.fr/" style="text-decoration:none;">
+                {% if logo_path %}
+                    <img src="{{ logo_path }}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% else %}
+                    <img src="{% static 'asso_tn/M-logo_colored-32.png' %}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% endif %}
+            </a>
+        </td> <!-- End Logo -->
+    </tr>
+    <tr> {% comment %} Title and Body_1 {% endcomment %}
+        <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
+            <h1 style="margin-top:0;margin-bottom:16px;font-size:26px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">
+                {{ email.title }}
+            </h1>
+            <p style="margin:0;">
+                {{ email.body_text_1_md }}
+                {% lorem 2 p %}
+            </p>
+        </td>
+    </tr> <!-- End of Body_1-->
+    {% if email.cta_1_slug %}
+        {% email_cta_button email.cta_1_slug email.cta_1_label %}
+    {% endif %}
+    {% if email.body_image_1 %}
+        {% email_full_width_image email.body_image_1.url email.body_image_1_alt_text %}
+    {% endif %}
+    {% email_body_text_md email.body_text_2_md %}
+    {% if email.body_image_2 %}
+        {% email_full_width_image email.body_image_2.url email.body_image_2_alt_text %}
+    {% endif %}
+    {% if  email.cta_2_slug %}
+        {% email_cta_button email.cta_2_slug email.cta_2_label %}
+    {% endif %}
+    <tr> <!-- Footer -->
+        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+            <p style="margin:0;font-size:14px;line-height:20px;">
+                &reg; Mobilitains 2022<br>
+                <a class="unsub" href="http://www.example.com/" style="color:#cccccc;text-decoration:underline;">Unsubscribe</a>
+            </p>
+        </td>
+    </tr> <!-- End of Footer -->
+</table>
+
+{% endblock email_content %}

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -1,0 +1,63 @@
+from django import template
+from django.urls import reverse_lazy
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def email_full_width_image(
+        filepath: str, alt_text: str,
+        link: str = "https://mobilitains.fr") -> str:
+    if not filepath:
+        return None
+    html_template = """
+    <tr>
+        <td
+        style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+            <a href="{link}" style="text-decoration:none;">
+                <img src="{filepath}" width="600" alt="{alt_text}"
+                style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+            </a>
+        </td>
+    </tr>
+    """.format(
+        filepath=filepath,
+        alt_text=alt_text,
+        link=link)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_body_text_md(text: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding:30px;background-color:#ffffff;">
+            <p style="margin:0;">
+                {text}
+            </p>
+        </td>
+    </tr>
+    """.format(text=text)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_cta_button(slug: str, label: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+        background-color:#ffffff;text-align:center;">
+            <p>
+                <a href="{slug}" class="btn
+                donation-button btn-lg">
+                {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                </a>
+            </p>
+        </td>
+    </tr>
+    """.format(
+        slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+        label=label
+        )
+    return mark_safe(html_template)

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -52,6 +52,10 @@ urlpatterns = [
     path('admin/e/list/<slug:the_slug>/', views.TopicBlogEmailList.as_view(),
          name='list_emails_by_slug'),
 
+    path('admin/e/send/<int:pkid>/<slug:the_slug>/<str:mailing_list_token>/',
+         views.TopicBlogEmailSendMail.as_view(),
+         name='send_email'),
+
     path('ajax/get-slug-dict/', views.get_slug_dict,
          name="get_slug_dict"),
     path('ajax/get-url-list/', views.get_url_list,

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -379,6 +379,14 @@ class TopicBlogEmailView(TopicBlogBaseView):
 class TopicBlogEmailViewOne(TopicBlogBaseViewOne):
     model = TopicBlogEmail
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        pkid = self.kwargs.get('pkid', -1)
+        the_slug = self.kwargs.get('the_slug', None)
+        tb_email = TopicBlogEmail.objects.get(pk=pkid, slug=the_slug)
+        context["email"] = tb_email
+        return context
+
 
 class TopicBlogEmailList(TopicBlogBaseList):
     model = TopicBlogEmail

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -382,8 +382,9 @@ class TopicBlogEmailView(TopicBlogBaseView):
     model = TopicBlogEmail
 
 
-class TopicBlogEmailViewOne(TopicBlogBaseViewOne):
+class TopicBlogEmailViewOne(PermissionRequiredMixin, TopicBlogBaseViewOne):
     model = TopicBlogEmail
+    permission_required = 'topicblog.tbe.may_view'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Add base template for TBEmails

It brings template tags to ease the creation of new templates,
and improves readability of the code.

The views allows us to send and see TBEmails in browser and mail
clients.

:warning: Let's note that for now, it does only check if the user has the permission to send emails, not if it's actually _published_  before proceeding. We haven't defined how to qualify a TBEmail as publishable / published.

For now no interface allows us to have a list of existing TBEmails (beside django admin) to publish them, and there isn't an implementation of publishable like TBItems.
So this is quite minimal, but we are able to 1) create a TBEmail through web form or Django admin 2) Send it to a mailing list, given you have to right to do so.

To send a TBEmail item, use the 'send_email' url, that is currently at this address : 
`/tb/admin/e/send/<pkid>/<slug>/<mailing_list_token>/`

You can preview the TBEmail on `/tb/admin/e/view/<pkid>/<slug>/` as usual.

Last, the image serving is dependent on your own settings.STATIC_URL and MEDIA_URL. the logo uses Static and the images, because they are ImageFields, use media. 
To have a proper display in your emails you can use prod's static and asset servers as urls.
For local use, simply "/static/" and "/media/" would do.  Just keep in mind that if you leave those defaults, the generated email will embed urls like "/static/path/of/image.jpg" which wont work in the context of mail clients. 

Closes #419