### PR TITLE
Fix order issue on slug: markdown directive

### DIFF
--- a/transport_nantes/topicblog/templatetags/slug.py
+++ b/transport_nantes/topicblog/templatetags/slug.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def tbi_slug(slug, label):
+def tbi_slug(label, slug):
     """Render an internal TBItem link from a slug.
 
     The value must include everything after "/tb/t/".

--- a/transport_nantes/topicblog/test_tn_links.py
+++ b/transport_nantes/topicblog/test_tn_links.py
@@ -100,8 +100,8 @@ class TnLinkParserTest(TestCase):
     def test_internal_url(self):
         the_slug = 'my-slug'
         the_label = 'my-label-text'
-        markdown = f'[[slug:{the_slug}]](({the_label}))'
-        html = slug.tbi_slug(the_slug, the_label)
+        markdown = f'[[slug:{the_label}]](({the_slug}))'
+        html = slug.tbi_slug(the_label, the_slug)
         self.assertEqual(self.parser.transform(markdown), html)
 
     def test_petition_url(self):


### PR DESCRIPTION
I'd inversed the label and slug.

Part of #497.