### PR TITLE
Add html_message argument to send_mail function

### DIFF
--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -5,7 +5,6 @@ from django.utils.crypto import get_random_string
 from django.views.generic.edit import FormView
 from django.core.mail import send_mail
 from django.contrib import auth
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
 from django.shortcuts import render, redirect
@@ -13,6 +12,7 @@ from django.template.loader import render_to_string
 from django.contrib.auth.views import LogoutView
 from django.conf import settings
 from django.urls import reverse
+from django.utils.html import strip_tags
 from django.views.generic.base import TemplateView
 
 from authentication.forms import (EmailLoginForm, PasswordLoginForm,
@@ -132,7 +132,11 @@ def send_activation(request, email, remember_me):
 
     """
     subject = 'sujet'
-    message = render_to_string(
+    # Emails can have a HTML version and a plain text alternative.
+    # https://docs.djangoproject.com/en/3.2/topics/email/#send-mail
+    # You can pass html to the send_mail function through the
+    # html_message argument.
+    html_message = render_to_string(
         'authentication/account_activation_email.html',
         {  # request.build_absolute_uri(),
             'scheme': request.scheme,
@@ -140,14 +144,15 @@ def send_activation(request, email, remember_me):
             'token': make_timed_token(email, 20),
             'remember_me': remember_me,
         })
-
+    plain_text_message = strip_tags(html_message)
     if hasattr(settings, 'ROLE') and settings.ROLE in ['beta', 'production']:
         try:
             send_mail(
                 subject,
-                message,
+                plain_text_message,
                 settings.DEFAULT_FROM_EMAIL,
                 [email],
+                html_message=html_message,
                 fail_silently=False)
         except Exception as e:
             logger.error(f"Error while sending mail to {email} : {e}")
@@ -155,7 +160,7 @@ def send_activation(request, email, remember_me):
     elif os.getenv('TEST_MODE', "0") == "0":
         # Only print this in dev mode, which is the only time
         # we'd care.
-        print(f"Sent message : \n{message}")
+        print(f"Sent message : \n{plain_text_message}")
 
 
 class ActivationLoginView(TemplateView):


### PR DESCRIPTION
This allows us to send both plain text and html versions of a message
in an email.

For instance, the magic token email. 

The template doesn't contain actual html tags in it (yet), the objective is to be consistent with the rest of the code regarding emails.

Part of #419