### PR TITLE
Fix the quick mailing list on production

### DIFF
--- a/transport_nantes/mailing_list/templates/mailing_list/first_step_sign_up_m.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/first_step_sign_up_m.html
@@ -1,0 +1,32 @@
+{% extends 'asso_tn/base_mobilitain.html' %}
+{% load static %}
+{% load don %}
+{% load mpanels %}
+{% load newsletter %}
+{% load crispy_forms_tags %}
+
+{% block og_title %}Inscrivez-vous à la newsletter des Mobilitains !{% endblock og_title %}
+{% block og_description %}Recevez chaque mois ou chaque trimestre des nouvelles essentielles de la mobilité en région nantaise.{% endblock og_description %}
+{% block og_image_url %}{% static 'asso_tn/images-quentin-boulegon/gilets-1.jpgasso_tn/images-libres/black-and-white-bridge-children-194009-1000.jpg' %}{% endblock og_image_url %}
+{% block og_image_alt %}Les actualités de la mobilité{% endblock og_image_alt %}
+{% block og_image_type %}image/jpg{% endblock og_image_type %}
+{% block og_image_width %}1000{% endblock og_image_width %}
+{% block og_image_height %}667{% endblock og_image_height %}
+{% block twitter_image %}{% static 'asso_tn/images-libres/black-and-white-bridge-children-194009-1000.jpg' %}{% endblock twitter_image %}
+{% block twitter_title %}Inscrivez-vous à la newsletter des Mobilitains !{% endblock twitter_title %}
+{% block twitter_description %}Recevez chaque mois ou chaque trimestre des nouvelles essentielles de la mobilité en région nantaise.{% endblock twitter_description %}
+
+{% block app_content %}
+
+<div class="container pt-5" id="mailing-list-first-step-page">
+    {% show_mailing_list  mailinglist="general-quarterly" title="Inscription à la newsletter" %}
+
+    <div class="row pt-4">
+	{% show_projects %}
+    </div>
+</div>
+
+{% show_donate %}
+{% show_volunteer %}
+
+{% endblock %}

--- a/transport_nantes/mailing_list/tests.py
+++ b/transport_nantes/mailing_list/tests.py
@@ -1,3 +1,104 @@
-from django.test import TestCase
+from django.test import LiveServerTestCase
+from selenium.webdriver.chrome.webdriver import WebDriver
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.options import Options
+from topicblog.models import TopicBlogItem
+from datetime import datetime, timezone
+from .models import MailingList, MailingListEvent
+from django.contrib.auth.models import User
+from django.urls import reverse
 
-# Create your tests here.
+
+class MailingListIntegrationTestCase(LiveServerTestCase):
+    def setUp(self):
+        self.user_permited = User.objects.create_user(username='ml-staff',
+                                                      password='ml-staff',
+                                                      email="staff@nomail.fr")
+        # Create a topicblog page for testing quick sign up
+        self.home = TopicBlogItem.objects.create(
+            slug="home",
+            date_modified=datetime.now(timezone.utc),
+            publication_date=datetime.now(timezone.utc),
+            first_publication_date=datetime.now(timezone.utc),
+            user=self.user_permited,
+            template_name="topicblog/content.html",
+            title="home-title")
+        # Create the default mailing list
+        self.mailing_list_default = MailingList.objects.create(
+            mailing_list_name="general-quarterly",
+            mailing_list_token="general-quarterly",
+            contact_frequency_weeks=1,
+            list_active=True,
+        )
+
+        options = Options()
+        options.add_argument("--headless")
+        options.add_argument("--disable-extensions")
+        self.selenium = WebDriver(ChromeDriverManager().install(),
+                                  options=options)
+        self.selenium.implicitly_wait(5)
+
+    def tearDown(self):
+        # Close the browser
+        self.selenium.quit()
+
+    def testing_quick_form(self):
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("topicblog:view_item_by_slug",
+                                            kwargs={
+                                                "the_slug": self.home.slug
+                                            })))
+        email_input = self.selenium.find_element_by_id("id_email")
+        email_input.send_keys("nomail@nomail.fr")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        # pass the captcha only work on dev mod
+        captcha_input = self.selenium.find_element_by_id("id_captcha_1")
+        captcha_input.send_keys("PASSED")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        user = User.objects.filter(email="nomail@nomail.fr")[0]
+        self.assertIsNotNone(user,
+                             msg="The user is not created on quick sign up")
+        mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+        self.assertIsNotNone(mailing_list_event,
+                             msg="The mailing event is not created"
+                                 "on quick sign up")
+
+        self.assertEqual(mailing_list_event.event_type, "sub",
+                         msg="The user is not sub on the default mailing list")
+
+    def testing_access_to_thanks_without_previous_post(self):
+        with self.settings(ROLE='production'):
+            self.selenium.get('%s%s' % (self.live_server_url,
+                                        reverse("mailing_list:list_ok")))
+            good_url_0 = \
+                (f"{self.live_server_url}"
+                 f"{reverse('mailing_list:first_step_quick_list_signup')}")
+            self.assertEqual(self.selenium.current_url, good_url_0,
+                             msg="User should be redirect to register page "
+                             "on production")
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("mailing_list:list_ok")))
+        good_url_1 = (f"{self.live_server_url}"
+                      f"{reverse('mailing_list:list_ok')}")
+        self.assertEqual(self.selenium.current_url, good_url_1,
+                         msg="User should see the page on dev role")
+
+    def testing_access_to_quick_list_signup_without_previous_post(self):
+        with self.settings(ROLE='production'):
+            self.selenium.get('%s%s' % (self.live_server_url,
+                                        reverse(
+                                            "mailing_list:quick_list_signup")))
+            good_url_0 = \
+                (f"{self.live_server_url}"
+                 f"{reverse('mailing_list:first_step_quick_list_signup')}")
+            self.assertEqual(self.selenium.current_url, good_url_0,
+                             msg="User should be redirect to register page "
+                             "on production")
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("mailing_list:quick_list_signup")))
+        good_url_1 = (f"{self.live_server_url}"
+                      f"{reverse('mailing_list:quick_list_signup')}")
+        self.assertEqual(self.selenium.current_url, good_url_1,
+                         msg="User should see the page on dev role")

--- a/transport_nantes/mailing_list/urls.py
+++ b/transport_nantes/mailing_list/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.conf import settings
 from .views import (MailingListSignup, QuickMailingListSignup,
                     QuickPetitionSignup, PetitionView, MailingListMerci,
                     MailingListListView, FirstStepQuickMailingListSignup)
@@ -18,13 +17,10 @@ urlpatterns = [
          template_name='mailing_list/petition4.html'),
          name='petition'),
 
-    path('list', MailingListListView.as_view(), name='list_items')
+    path('list', MailingListListView.as_view(), name='list_items'),
+    path('inscrire-captcha',
+         QuickMailingListSignup.as_view(),
+         name='quick_list_signup'),
+    path('merci', MailingListMerci.as_view(),
+         name='list_ok'),
 ]
-
-# For debugging the "thank you" template:
-if hasattr(settings, 'ROLE') and 'production' != settings.ROLE:
-    urlpatterns.append(path('merci', MailingListMerci.as_view(),
-                            name='list_ok'))
-    urlpatterns.append(path('inscrire-captcha',
-                            QuickMailingListSignup.as_view(),
-                            name='quick_list_signup'),)


### PR DESCRIPTION
Redirect all user on production who use get method on the QuickMailingListSignup and MailingListMerci view to the FirstStepQuickMailingListSignup view.