### PR TITLE
Fix the quick mailing list

### DIFF
--- a/transport_nantes/mailing_list/templates/mailing_list/panel/mailing_list.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/panel/mailing_list.html
@@ -1,13 +1,13 @@
 {% load crispy_forms_tags %}
 
-<div class="container py-5 d-flex justify-content-center">
+<div class="container py-5 d-flex justify-content-center" id="newsletter">
     <div class="row justify-content-center">
 	{% if title %}<div>
 	    <h2 >{{ title }}</h2>
 	</div>{% endif %}
 	<div class="d-flex col-sm-12 justify-content-center">
 	    <form class="d-flex flex-column" method="post"
-		  action="{% url 'mailing_list:first_step_quick_list_signup' %}">{% csrf_token %}
+		  action="{% url 'mailing_list:quick_signup' %}">{% csrf_token %}
 		{% if form.non_field_errors %}
 		<p>{{ form.non_field_errors }}</p>
 		{% endif %}
@@ -20,7 +20,7 @@
 		<p style="color: red">{{ error }}</p>
 		{% endfor %}
 		{% endfor %}
-		
+
 		<button type="submit" class="btn donation-button">Je m'inscris</button>
 	    </form>
 	</div>

--- a/transport_nantes/mailing_list/templatetags/newsletter.py
+++ b/transport_nantes/mailing_list/templatetags/newsletter.py
@@ -2,9 +2,9 @@ from django import template
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from mailing_list.forms import FirstStepQuickMailingListSignupForm
-from mailing_list.forms import QuickPetitionSignupForm
-
+from mailing_list.forms import (FirstStepQuickMailingListSignupForm, 
+                                QuickPetitionSignupForm)
+  
 register = template.Library()
 
 

--- a/transport_nantes/mailing_list/tests.py
+++ b/transport_nantes/mailing_list/tests.py
@@ -1,3 +1,107 @@
-from django.test import TestCase
+from django.test import LiveServerTestCase
+from selenium.webdriver.chrome.webdriver import WebDriver
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.options import Options
+from topicblog.models import TopicBlogItem
+from datetime import datetime, timezone
+from .models import MailingList, MailingListEvent
+from django.contrib.auth.models import User
+from django.urls import reverse
 
-# Create your tests here.
+
+class MailingListIntegrationTestCase(LiveServerTestCase):
+    def setUp(self):
+        self.user_permited = User.objects.create_user(username='ml-staff',
+                                                      password='ml-staff',
+                                                      email="staff@nomail.fr")
+        # Create a topicblog page for testing quick sign up
+        self.home = TopicBlogItem.objects.create(
+            slug="home",
+            date_modified=datetime.now(timezone.utc),
+            publication_date=datetime.now(timezone.utc),
+            first_publication_date=datetime.now(timezone.utc),
+            user=self.user_permited,
+            template_name="topicblog/content.html",
+            title="home-title")
+        # Create the default mailing list
+        self.mailing_list_default = MailingList.objects.create(
+            mailing_list_name="general-quarterly",
+            mailing_list_token="general-quarterly",
+            contact_frequency_weeks=1,
+            list_active=True,
+        )
+
+        options = Options()
+        options.add_argument("--headless")
+        options.add_argument("--disable-extensions")
+        self.selenium = WebDriver(ChromeDriverManager().install(),
+                                  options=options)
+        self.selenium.implicitly_wait(5)
+
+    def tearDown(self):
+        # Close the browser
+        self.selenium.quit()
+
+    def testing_quick_form(self):
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("topicblog:view_item_by_slug",
+                                            kwargs={
+                                                "the_slug": self.home.slug
+                                            })))
+        email_input = self.selenium.find_element_by_id("id_email")
+        email_input.send_keys("nomail@nomail.fr")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        # pass the captcha only work on dev mod
+        captcha_input = self.selenium.find_element_by_id("id_captcha_1")
+        captcha_input.send_keys("PASSED")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        user = User.objects.filter(email="nomail@nomail.fr")[0]
+        self.assertIsNotNone(user,
+                             msg="The user is not created on quick sign up")
+        mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+        self.assertIsNotNone(mailing_list_event,
+                             msg="The mailing event is not created"
+                                 "on quick sign up")
+
+        self.assertEqual(mailing_list_event.event_type, "sub",
+                         msg="The user is not sub on the default mailing list")
+
+    def testing_quick_form_fail_captcha(self):
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("topicblog:view_item_by_slug",
+                                            kwargs={
+                                                "the_slug": self.home.slug
+                                            })))
+        email_input = self.selenium.find_element_by_id("id_email")
+        email_input.send_keys("nomail@nomail.fr")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        # fail the capcha
+        captcha_input = self.selenium.find_element_by_id("id_captcha_1")
+        captcha_input.send_keys("Notgood")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        # pass the captcha only work on dev mod
+        captcha_input = self.selenium.find_element_by_id("id_captcha_1")
+        captcha_input.send_keys("PASSED")
+        self.selenium.find_element_by_css_selector(
+            "form button[type=submit]").click()
+        user = User.objects.filter(email="nomail@nomail.fr")[0]
+        self.assertIsNotNone(user,
+                             msg="The user is not created on quick sign up")
+        mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+        self.assertIsNotNone(mailing_list_event,
+                             msg="The mailing event is not created"
+                                 "on quick sign up")
+
+        self.assertEqual(mailing_list_event.event_type, "sub",
+                         msg="The user is not sub on the default mailing list")
+
+    def testing_acces_with_get_to_the_quick_form(self):
+        self.selenium.get('%s%s' % (self.live_server_url,
+                                    reverse("mailing_list:quick_signup")))
+        index_url = f"{self.live_server_url}{reverse('index')}#newsletter"
+        self.assertEqual(self.selenium.current_url, index_url,
+                         msg="User should be redirect to index page")

--- a/transport_nantes/mailing_list/urls.py
+++ b/transport_nantes/mailing_list/urls.py
@@ -1,16 +1,15 @@
 from django.urls import path
 from django.conf import settings
-from .views import (MailingListSignup, QuickMailingListSignup,
-                    QuickPetitionSignup, PetitionView, MailingListMerci,
-                    MailingListListView, FirstStepQuickMailingListSignup)
+from .views import (MailingListSignup, QuickPetitionSignup, PetitionView,
+                    MailingListListView,  QuickMailingListSignup)
 
 app_name = 'mailing_list'
 urlpatterns = [
     path('inscrire', MailingListSignup.as_view(),
          name='list_signup'),
 
-    path('etape-un-inscription', FirstStepQuickMailingListSignup.as_view(),
-         name='first_step_quick_list_signup'),
+    path('newsletters-signup',  QuickMailingListSignup.as_view(),
+         name='quick_signup'),
 
     path('petition-captcha', QuickPetitionSignup.as_view(),
          name='quick_petition_signup'),
@@ -20,11 +19,3 @@ urlpatterns = [
 
     path('list', MailingListListView.as_view(), name='list_items')
 ]
-
-# For debugging the "thank you" template:
-if hasattr(settings, 'ROLE') and 'production' != settings.ROLE:
-    urlpatterns.append(path('merci', MailingListMerci.as_view(),
-                            name='list_ok'))
-    urlpatterns.append(path('inscrire-captcha',
-                            QuickMailingListSignup.as_view(),
-                            name='quick_list_signup'),)


### PR DESCRIPTION
The QuickMailingListSignup view now handles all the steps of the form:

-  enter the email
-  enter the mail and the captcha
- if the previous form is valid create the MailistEvent and show the thanks page

if user try to access with a get request he will be redirected to the index at the newsletter subscription form.