### PR TITLE
Add the mailing list   unsubscribe with token page

### DIFF
--- a/transport_nantes/asso_tn/tests.py
+++ b/transport_nantes/asso_tn/tests.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 import datetime
-
 from .utils import make_timed_token, token_valid
+from django.contrib.auth.models import User
+from mailing_list.models import MailingList
+from topicblog.models import TopicBlogEmailSendRecord
 
 
 class TimedTokenTest(TestCase):
@@ -28,3 +30,33 @@ class TimedTokenTest(TestCase):
             after_response = token_valid(token, NOW + EXPIRY_SECONDS + 1)
             self.assertEqual(after_response[0], None)
             self.assertEqual(after_response[1], 0)
+
+    def test_mailing_list_token(self):
+        """Testing the result of make_timed_token with
+            mailing parameters and test the result with
+            token valid"""
+        # Create a User object
+        user = User.objects.create_user(username='user',
+                                        password='password',
+                                        email="duponttesteur@test.fr"
+                                        )
+        # Create a MailingList object
+        mailing_list = MailingList.objects.create(
+            mailing_list_name="news1",
+            mailing_list_token="token1",
+            list_active=True,
+        )
+        # Create a TopicBlogEmailSendRecord object with a fake id
+        tb_send_email_record = TopicBlogEmailSendRecord(
+            id=1,
+            mailinglist=mailing_list,
+            recipient=user
+        )
+
+        token = \
+            make_timed_token(user.email, 1080, 1234,
+                             tb_email_send_record_id=tb_send_email_record.id,)
+        now_response = token_valid(token)
+        self.assertEqual(now_response[0], user.email)
+        self.assertEqual(now_response[1], tb_send_email_record.id)
+        self.assertEqual(now_response[2], 1234)

--- a/transport_nantes/mailing_list/templates/mailing_list/last_part_unsubscribe.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/last_part_unsubscribe.html
@@ -1,0 +1,16 @@
+{% extends 'asso_tn/base_mobilitain.html' %}
+{% load mpanels %}
+{% block app_content %}
+<div class="container pt-5">
+    <div class="row">
+        <div class="col-md-12">
+            <p>Vous avez bien été désinscrit de la newsletter.</p>
+        </div>
+    </div>
+    <div class="row pt-4">
+	{% show_projects %}
+    </div>
+</div>
+{% show_donate %}
+{% show_volunteer %}
+{% endblock %}

--- a/transport_nantes/mailing_list/templates/mailing_list/status/hidden_form.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/status/hidden_form.html
@@ -1,4 +1,8 @@
-<form method="post" action="{% url 'mailing_list:toggle_subscription' %}">
+<form method="post"
+    {% if not is_from_token %}
+        action="{% url 'mailing_list:toggle_subscription' %}"
+    {% endif %}
+    >
     {% csrf_token %}
     <input type="hidden" id="mailinglist" name="mailinglist" value="{{mailing_list.id}}">
     {% comment %} If this is a unsub form show the back button {% endcomment %}
@@ -8,7 +12,11 @@
                     <button type="submit" class="btn navigation-button btn-lg btn-block">{{button_label}}</button>
             </div>
             <div class="col-md-6">
-                <a href="{% url 'mailing_list:user_status' %}" class="btn navigation-button btn-lg btn-block">Retour</a>
+                {% if back_index %}
+                    <a href="{% url 'index' %}" class="btn navigation-button btn-lg btn-block">Retour</a>
+                {% else %}
+                    <a href="{% url 'mailing_list:user_status' %}" class="btn navigation-button btn-lg btn-block">Retour</a>
+                {% endif %}
             </div>
         </div>
     {% else %}

--- a/transport_nantes/mailing_list/templates/mailing_list/validate_form.html
+++ b/transport_nantes/mailing_list/templates/mailing_list/validate_form.html
@@ -11,9 +11,19 @@
 		{% if form.errors %}
 			<p class="text-danger">{{ form.errors }}</p>
 		{% endif %}
-		<h5 class="alert alert-danger text-center">Vous êtes sur le point de vous désinscire de la newsletter</h5>
-		<p>Newsletter :  {{mailing_list.mailing_list_name}}</p>
-        {% include "mailing_list/status/hidden_form.html"  with unsubscribe=True button_label="Confirmer"  %}
+        {% if is_unsub %}
+			<h5 class="alert alert-danger text-center">Vous êtes déja désabonné à cette newsletter</h5>
+			<p>Newsletter :  {{mailing_list.mailing_list_name}}</p>
+			<a href="{% url 'index' %}" class="btn navigation-button btn-lg">Retour</a>
+		{% else %}
+		    <h5 class="alert alert-danger text-center">Vous êtes sur le point de vous désinscire de la newsletter</h5>
+		    <p>Newsletter :  {{mailing_list.mailing_list_name}}</p>
+            {% if is_from_token %}
+                {% include "mailing_list/status/hidden_form.html"  with unsubscribe=True back_index=True button_label="Confirmer"  %}
+            {% else %}
+                {% include "mailing_list/status/hidden_form.html"  with unsubscribe=True button_label="Confirmer"  %}
+            {% endif %}
+        {% endif %}
 	</div>
     </div>
     <div class="row pt-4">

--- a/transport_nantes/mailing_list/urls.py
+++ b/transport_nantes/mailing_list/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
-from django.conf import settings
 from .views import (MailingListSignup, QuickPetitionSignup, PetitionView,
                     MailingListListView,  QuickMailingListSignup,
-                    UserStatusView, MailingListToggleSubscription)
+                    UserStatusView, MailingListToggleSubscription,
+                    MailingListUnsubscribeWithToken, UnsubscribeView,)
 
 app_name = 'mailing_list'
 urlpatterns = [
@@ -21,7 +21,13 @@ urlpatterns = [
     path('list', MailingListListView.as_view(), name='list_items'),
 
     path('status', UserStatusView.as_view(), name='user_status'),
-    
+
     path('toggle_subscription', MailingListToggleSubscription.as_view(),
          name='toggle_subscription'),
+
+    path('unsubscribe/<str:token>', MailingListUnsubscribeWithToken.as_view(),
+         name='unsubscribe_token'),
+
+    path('unsubscribed', UnsubscribeView.as_view(),
+         name='unsubscribe_finish'),
 ]


### PR DESCRIPTION
Add the first part of the 487 issue : 
User unsubscribe page for one list. (Note: not for petitions.) If the user is not subscribed (note that we already have a function to check), just say so. Otherwise, offer to unsubscribe. Present a button that, on click, writes an unsubscribe event and confirms for the user that this is done. Unsubscribing more than once is not an error (if, somehow, the user prepares a bunch of pages to unsubscribe).