### PR TITLE
Add email send view 402

### DIFF
--- a/transport_nantes/mailing_list/models.py
+++ b/transport_nantes/mailing_list/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from django.contrib.auth.models import User
 import django.utils.timezone
 
-
 # This application might have been called newsletter.  Think of this
 # as about newsletters, not about the lists, in the sense that this is
 # an application that is designed for keeping in touch with lists of

--- a/transport_nantes/topicblog/templates/topicblog/TBEmail/base_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/TBEmail/base_email.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="https://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="x-apple-disable-message-reformatting">
+    <title></title>
+    {% comment %}
+        Some CSS and PNG sizing resets for Microsoft Outlook on Windows
+        hidden inside conditional comments (the <!--[if mso]> bits)
+        src : https://webdesign.tutsplus.com/articles/creating-a-simple-responsive-html-email--webdesign-12978
+    {% endcomment %}
+    <!--[if mso]>
+    <style>
+        table {border-collapse:collapse;border-spacing:0;border:none;margin:0;}
+        div, td {padding:0;}
+        div {margin:0 !important;}
+    </style>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+    <style>
+        table, td, div, h1, p {
+            font-family: Arial, sans-serif;
+        }
+        @media screen and (max-width: 530px) {
+            .unsub {
+                display: block;
+                padding: 8px;
+                margin-top: 14px;
+                border-radius: 6px;
+                background-color: #555555;
+                text-decoration: none !important;
+                font-weight: bold;
+            }
+            .col-lge {
+                max-width: 100% !important;
+            }
+        }
+        @media screen and (min-width: 531px) {
+            .col-sml {
+                max-width: 27% !important;
+            }
+            .col-lge {
+                max-width: 73% !important;
+            }
+        }
+        a:link.donation-button {
+            color: white;
+            font-weight: 600;
+            background-color: #5BC2E7;
+            border-radius: 0;
+        }
+        a:visited.donation-button {
+            color: white;
+        }
+        a:hover.donation-button {
+            color: white;
+        }
+        .donation-button {
+            background-color: #5BC2E7;
+            color:white;
+            font-weight: 600;
+        }
+        .btn.donation-button:hover {
+            color:white;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 400;
+            color: #212529;
+            text-align: center;
+            vertical-align: middle;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            background-color: transparent;
+            border: 1px solid transparent;
+            padding: .375rem .75rem;
+            font-size: 1rem;
+            line-height: 1.5;
+            border-radius: .25rem;
+            transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+            text-decoration: none;
+        }
+    </style>
+    <script src="https://kit.fontawesome.com/46b82563d9.js" crossorigin="anonymous"></script>
+</head>
+<body style="margin:0;padding:0;word-spacing:normal;background-color:#939297;">
+    <div role="article" aria-roledescription="email" lang="fr"
+    style="text-size-adjust:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;background-color:#939297;">
+        {% comment %}
+        This scaffold is necessary so that our email will be centered across all email clients.
+        We create a 100% wide table, and then set the border and border-spacing to zero.
+        Then we create a row and table cell with no padding which has align="center" set so that its contents will be centered.
+        {% endcomment %}
+        <table role="presentation" style="width:100%;border:none;border-spacing:0;">
+            <tr>
+                <td align="center" style="padding:0;">
+                {% comment %}
+                Before adding our main content container, we need to set up a Ghost Table:
+                a rigid table with a fixed width that only renders in Outlook because it’s hidden
+                inside some special Outlook-only conditional comments. We need to do this because
+                our main container is going to use the CSS max-width property, and not all versions
+                of Outlook for Windows support it. Without max-width support, the main container
+                would explode to full-width when viewed in Outlook for Windows, so we need to contain it.
+                {% endcomment %}
+                    <!--[if mso]>
+                        <table role="presentation" align="center" style="width:600px;">
+                        <tr>
+                        <td>
+                    <![endif]-->
+                        {% block email_content %}{% endblock email_content %}
+                    <!--[if mso]>
+                        </td>
+                        </tr>
+                        </table>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/transport_nantes/topicblog/templates/topicblog/TBEmail/email.html
+++ b/transport_nantes/topicblog/templates/topicblog/TBEmail/email.html
@@ -1,0 +1,58 @@
+{% extends 'topicblog/TBEmail/base_email.html' %}
+{% load static %}
+{% load email_tags %}
+
+{% block email_content %}
+
+{% comment %} This table is the main container{% endcomment %}
+<table role="presentation"
+style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
+    <tr>
+        {% comment "Logo" %}This row handles the logo display{% endcomment %}
+        <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">
+            <a href="https://www.mobilitains.fr/" style="text-decoration:none;">
+                {% if logo_path %}
+                    <img src="{{ logo_path }}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% else %}
+                    <img src="{% static 'asso_tn/M-logo_colored-32.png' %}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% endif %}
+            </a>
+        </td> <!-- End Logo -->
+    </tr>
+    <tr> {% comment %} Title and Body_1 {% endcomment %}
+        <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
+            <h1 style="margin-top:0;margin-bottom:16px;font-size:26px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">
+                {{ email.title }}
+            </h1>
+            <p style="margin:0;">
+                {{ email.body_text_1_md }}
+                {% lorem 2 p %}
+            </p>
+        </td>
+    </tr> <!-- End of Body_1-->
+    {% if email.cta_1_slug %}
+        {% email_cta_button email.cta_1_slug email.cta_1_label %}
+    {% endif %}
+    {% if email.body_image_1 %}
+        {% email_full_width_image email.body_image_1.url email.body_image_1_alt_text %}
+    {% endif %}
+    {% email_body_text_md email.body_text_2_md %}
+    {% if email.body_image_2 %}
+        {% email_full_width_image email.body_image_2.url email.body_image_2_alt_text %}
+    {% endif %}
+    {% if  email.cta_2_slug %}
+        {% email_cta_button email.cta_2_slug email.cta_2_label %}
+    {% endif %}
+    <tr> <!-- Footer -->
+        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+            <p style="margin:0;font-size:14px;line-height:20px;">
+                &reg; Mobilitains 2022<br>
+                <a class="unsub" href="http://www.example.com/" style="color:#cccccc;text-decoration:underline;">Unsubscribe</a>
+            </p>
+        </td>
+    </tr> <!-- End of Footer -->
+</table>
+
+{% endblock email_content %}

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -1,0 +1,61 @@
+from django import template
+from django.urls import reverse_lazy
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def email_full_width_image(
+        filepath: str, alt_text: str,
+        link: str = "https://mobilitains.fr") -> str:
+    html_template = """
+    <tr>
+        <td
+        style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+            <a href="{link}" style="text-decoration:none;">
+                <img src="{filepath}" width="600" alt="{alt_text}"
+                style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+            </a>
+        </td>
+    </tr>
+    """.format(
+        filepath=filepath,
+        alt_text=alt_text,
+        link=link)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_body_text_md(text: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding:30px;background-color:#ffffff;">
+            <p style="margin:0;">
+                {text}
+            </p>
+        </td>
+    </tr>
+    """.format(text=text)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_cta_button(slug: str, label: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+        background-color:#ffffff;text-align:center;">
+            <p>
+                <a href="{slug}" class="btn
+                donation-button btn-lg">
+                {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                </a>
+            </p>
+        </td>
+    </tr>
+    """.format(
+        slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+        label=label
+        )
+    return mark_safe(html_template)

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -1,0 +1,96 @@
+from django.conf import settings
+from django.template import Template, Context
+from django.test import TestCase
+from django.urls import reverse_lazy
+
+
+class TBEmailTemplateTagsTests(TestCase):
+
+    def test_email_full_width_image(self):
+        # An existing static image
+        filepath = "asso_tn/belvederes.jpg"
+        alt_text = "Belvederes"
+        link = "https://mobilitains.fr"
+        template_string = (
+            "{% load static %}{% load email_tags %}"
+            "{% static "f"'{filepath}'"" as filepath %}"
+            "{% email_full_width_image filepath " f"'{alt_text}' '{link}'"
+            " %}")
+        context = Context()
+        rendered_template = Template(template_string).render(context)
+        # Exepcted result is from email_full_width_image's code.
+        expected_template = f"""
+        <tr>
+            <td
+            style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+                <a href="{link}" style="text-decoration:none;">
+                    <img src="{settings.STATIC_URL}{filepath}" width="600" alt="{alt_text}"
+                    style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+                </a>
+            </td>
+        </tr>
+        """.format( # noqa
+            filepath=filepath,
+            alt_text=alt_text,
+            link=link)
+
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_body_text_md(self):
+
+        text = "This is a test"
+        expected_template = \
+            f"""
+            <tr>
+                <td style="padding:30px;background-color:#ffffff;">
+                    <p style="margin:0;">
+                        {text}
+                    </p>
+                </td>
+            </tr>
+            """
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_body_text_md text %}")
+        context = Context({"text": text})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_cta_button(self):
+
+        slug = "index"
+        label = "Go to the homepage"
+        expected_template = """
+        <tr>
+            <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+            background-color:#ffffff;text-align:center;">
+                <p>
+                    <a href="{slug}" class="btn
+                    donation-button btn-lg">
+                    {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                    </a>
+                </p>
+            </td>
+        </tr>
+        """.format(
+            slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+            label=label
+        )
+
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_cta_button slug label %}")
+        context = Context({"slug": slug, "label": label})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -1,8 +1,12 @@
 from datetime import datetime, timedelta, timezone
-from django.test import TestCase, Client
-from .models import TopicBlogItem
+
 from django.contrib.auth.models import Permission, User
+from django.test import Client, TestCase
 from django.urls import reverse
+from mailing_list.models import MailingList
+from mailing_list.events import subscribe_user_to_list
+
+from .models import TopicBlogEmail, TopicBlogItem
 
 
 class Test(TestCase):
@@ -865,7 +869,7 @@ class TBIView(TestCase):
             - client = the client of user (auth user, unauth and staff user)
             - code = the statut code (not varie for user)
             - message = the error message (not varie for user)"""
-        
+
         self.users_expected = [
             {"client": self.client, "code": 403,
              "msg": "User with no staff status is not permited"},
@@ -912,3 +916,77 @@ class TBIView(TestCase):
         # test the result of the staff user
         self.assertJSONEqual(str(response.content, encoding='utf8'),
                              {"url": "/tb/admin/t/list/test-slug-no-alt/"})
+
+
+class TopicBlogEmailTest(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="test_user",
+            email="admin@admin.com",
+            password="test_password")
+        self.email_article = TopicBlogEmail.objects.create(
+            subject="Test subject",
+            user=self.superuser,
+            body_text_1_md="Test body text 1",
+            slug="test-email",
+            publication_date=datetime.now(timezone.utc),
+            first_publication_date=datetime.now(timezone.utc),
+            template_name="topicblog/TBEmail/email.html",
+            title="Test title")
+        self.mailing_list = MailingList.objects.create(
+            mailing_list_name="the_mailing_list_name",
+            mailing_list_token="the_mailing_list_token",
+            contact_frequency_weeks=12,
+            list_active=True)
+        self.no_permissions_user = User.objects.create_user(
+            username="user_without_permissions",
+            email="test@test.com"
+        )
+        subscribe_user_to_list(self.superuser, self.mailing_list)
+        subscribe_user_to_list(self.no_permissions_user, self.mailing_list)
+        self.no_permissions_client = Client()
+        self.admin_client = Client()
+        self.admin_client.force_login(self.superuser)
+        self.no_permissions_client.force_login(self.no_permissions_user)
+
+        # Anonymous users are invited tol og in and from there, you
+        # land either on 403 Forbidden or 200 OK depending on the
+        # user's permissions.
+        self.perm_needed_responses = [
+            {"client": self.client, "code": 302,
+             "msg": "Anonymous users are redirected to login."},
+            {"client": self.no_permissions_client, "code": 403,
+             "msg": ("Logged in users without proper permissions can't have "
+                     "access to this page.")},
+            {"client": self.admin_client, "code": 200,
+             "msg": "The page must return 200 the user has the permission."}
+        ]
+        self.no_perm_needed_responses = [
+            {"client": self.client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."},
+            {"client": self.no_permissions_client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."},
+            {"client": self.admin_client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."}
+        ]
+
+    def test_TBE_view_one_status_code(self):
+
+        for user_type in self.perm_needed_responses:
+            response = user_type["client"].get(
+                reverse('topic_blog:view_email_by_pkid',
+                        args=[self.email_article.pk, self.email_article.slug]
+                        )
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+
+    def test_TBE_view_status_code(self):
+        for user_type in self.no_perm_needed_responses:
+            response = user_type["client"].get(
+                reverse('topic_blog:view_email_by_slug',
+                        args=[self.email_article.slug]
+                        )
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -4,7 +4,9 @@ from django.contrib.auth.models import Permission, User
 from django.test import Client, TestCase
 from django.urls import reverse
 from mailing_list.models import MailingList
-from mailing_list.events import subscribe_user_to_list
+from mailing_list.events import (get_subcribed_users_email_list,
+                                 unsubscribe_user_from_list,
+                                 subscribe_user_to_list)
 
 from .models import TopicBlogEmail, TopicBlogItem
 
@@ -990,3 +992,18 @@ class TopicBlogEmailTest(TestCase):
             )
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
+
+    def test_get_subcribed_users_email_list(self):
+
+        # superuser and no_perm_user are subscribed to the mailing list
+        # in the setUp method
+        number_of_subscribed_users = 2
+        self.assertEqual(
+            len(get_subcribed_users_email_list(self.mailing_list)),
+            number_of_subscribed_users)
+
+        unsubscribe_user_from_list(self.superuser, self.mailing_list)
+        number_of_subscribed_users = 1
+        self.assertEqual(
+            len(get_subcribed_users_email_list(self.mailing_list)),
+            number_of_subscribed_users)

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -52,7 +52,8 @@ urlpatterns = [
     path('admin/e/list/<slug:the_slug>/', views.TopicBlogEmailList.as_view(),
          name='list_emails_by_slug'),
 
-    path('admin/e/send/<slug:the_slug>/', views.TopicBlogEmailSend.as_view(),
+    path('admin/e/send/<int:pkid>/<slug:the_slug>/<str:mailing_list_token>/',
+         views.TopicBlogEmailSendMail.as_view(),
          name='send_email'),
 
     path('ajax/get-slug-dict/', views.get_slug_dict,

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -380,6 +380,7 @@ class TopicBlogEmailViewOnePermissions(PermissionRequiredMixin):
             return user.has_perm('topicblog.tbe.may_view')
         return super().has_permission()
 
+
 class TopicBlogEmailEdit(TopicBlogBaseEdit):
     model = TopicBlogEmail
     template_name = 'topicblog/tb_item_edit.html'
@@ -391,23 +392,29 @@ class TopicBlogEmailView(TopicBlogBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_email.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_email.html'
         tb_object = context['page']
         user = self.request.user
         if user.has_perm('topicblog.tbe.may_send_self') or \
-           (user.has_perm('topicblog.tbe.may_send') \
-            and tb_object.publisher != user):
+           (user.has_perm('topicblog.tbe.may_send')
+                and tb_object.publisher != user):
             context['sendable'] = True
         return context
 
 
-class TopicBlogEmailViewOne(TopicBlogEmailViewOnePermissions,
-                            TopicBlogBaseViewOne):
+class TopicBlogEmailViewOne(PermissionRequiredMixin, TopicBlogBaseViewOne):
     model = TopicBlogEmail
+    permission_required = 'topicblog.tbe.may_view'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_email.html'
+        pkid = self.kwargs.get('pkid', -1)
+        the_slug = self.kwargs.get('the_slug', None)
+        tb_email = TopicBlogEmail.objects.get(pk=pkid, slug=the_slug)
+        context["email"] = tb_email
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_email.html'
         return context
 
 
@@ -422,6 +429,7 @@ class TopicBlogEmailList(TopicBlogBaseList):
             return ['topicblog/topicblogemail_list_one.html'] + names
         else:
             return names
+
 
 class TopicBlogEmailSend(LoginRequiredMixin, TemplateView):
     """Notes to Benjamin and Mickael:


### PR DESCRIPTION
This PR is based on the PR #511 

Adds a view that, if the user has the permission, sends to a mailing list the given TBEmail.

For now the view renders the Email (because it's easier to see the result straight away), but we could just return a 200 code and be done with it. 
I guess we will think of other ways to send mails (through a dashboard for example), but as we didn't this part yet, the view will work in the meantime. 

Note : For test purpose, only @mobilitain.fr addresses are valid as recipients.

Closes #402 