### PR TITLE
Tbe send implementation 532

### DIFF
--- a/transport_nantes/mailing_list/events.py
+++ b/transport_nantes/mailing_list/events.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.db.models import Max
 from django.db.models import Q
 
-from .models import MailingListEvent
+from .models import MailingList, MailingListEvent
 
 
 def subscribe_user_to_list(user, mailing_list) -> MailingListEvent:
@@ -13,7 +13,6 @@ def subscribe_user_to_list(user, mailing_list) -> MailingListEvent:
         mailing_list=mailing_list,
         event_type=MailingListEvent.EventType.SUBSCRIBE)
     subscribe.save()
-
 
 
 def unsubscribe_user_from_list(user, mailing_list) -> MailingListEvent:
@@ -82,3 +81,23 @@ def subscriber_count(mailing_list):
     users_subscribed = user_states.filter(
         Q(event_type=MailingListEvent.EventType.SUBSCRIBE)).count()
     return users_subscribed
+
+
+def get_subcribed_users_email_list(mailing_list: MailingList) -> list:
+    """Return a list of email addresses of users subscribed to this list.
+    """
+    # Returns a set of user PK that subscribed to this list at least once.
+    set_of_once_subscribed_users = set(MailingListEvent.objects.filter(
+        mailing_list__mailing_list_token=mailing_list.mailing_list_token
+        ).values_list("user", flat=True))
+    # Get the list of subscribed users.
+    subscribed_users = []
+    for user_id in set_of_once_subscribed_users:
+        user = User.objects.get(pk=user_id)
+        latest_event = user_current_state(
+            user,
+            mailing_list)
+        if latest_event.event_type == "sub":
+            subscribed_users.append(user.email)
+
+    return subscribed_users

--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.forms import ModelForm
 from .models import TopicBlogItem
+from mailing_list.models import MailingList
 
 
 class TopicBlogItemForm(ModelForm):
@@ -36,3 +37,23 @@ class TopicBlogItemForm(ModelForm):
         self.fields['template'] = forms.ChoiceField(
             choices=template_list,
             initial=self.instance.template_name)
+
+
+class TopicBlogEmailSendForm(forms.Form):
+    """
+    Generates a form that shows available mailing lists to send
+    a given TBEmail.
+    """
+    # Get a list of mailing lists with their names and tokens
+    all_mailing_lists = MailingList.objects.all().values(
+        "mailing_list_name", "mailing_list_token")
+    all_mailing_lists = \
+        [(item["mailing_list_token"], item["mailing_list_name"])
+         for item in all_mailing_lists]
+    # Add a default value
+    all_mailing_lists.insert(0, (None, "Selectionnez une liste d'envoi ..."))
+
+    mailing_list = forms.ChoiceField(
+        choices=all_mailing_lists,
+        label="Liste d'envoi",
+        required=True)

--- a/transport_nantes/topicblog/templates/topicblog/base_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_email_client.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="https://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="x-apple-disable-message-reformatting">
+    <title></title>
+    {% comment %}
+        Some CSS and PNG sizing resets for Microsoft Outlook on Windows
+        hidden inside conditional comments (the <!--[if mso]> bits)
+        src : https://webdesign.tutsplus.com/articles/creating-a-simple-responsive-html-email--webdesign-12978
+    {% endcomment %}
+    <!--[if mso]>
+    <style>
+        table {border-collapse:collapse;border-spacing:0;border:none;margin:0;}
+        div, td {padding:0;}
+        div {margin:0 !important;}
+    </style>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+    <style>
+        table, td, div, h1, p {
+            font-family: Arial, sans-serif;
+        }
+        @media screen and (max-width: 530px) {
+            .unsub {
+                display: block;
+                padding: 8px;
+                margin-top: 14px;
+                border-radius: 6px;
+                background-color: #555555;
+                text-decoration: none !important;
+                font-weight: bold;
+            }
+            .col-lge {
+                max-width: 100% !important;
+            }
+        }
+        @media screen and (min-width: 531px) {
+            .col-sml {
+                max-width: 27% !important;
+            }
+            .col-lge {
+                max-width: 73% !important;
+            }
+        }
+        a:link.donation-button {
+            color: white;
+            font-weight: 600;
+            background-color: #5BC2E7;
+            border-radius: 0;
+        }
+        a:visited.donation-button {
+            color: white;
+        }
+        a:hover.donation-button {
+            color: white;
+        }
+        .donation-button {
+            background-color: #5BC2E7;
+            color:white;
+            font-weight: 600;
+        }
+        .btn.donation-button:hover {
+            color:white;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 400;
+            color: #212529;
+            text-align: center;
+            vertical-align: middle;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            background-color: transparent;
+            border: 1px solid transparent;
+            padding: .375rem .75rem;
+            font-size: 1rem;
+            line-height: 1.5;
+            border-radius: .25rem;
+            transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+            text-decoration: none;
+        }
+    </style>
+    <script src="https://kit.fontawesome.com/46b82563d9.js" crossorigin="anonymous"></script>
+</head>
+<body style="margin:0;padding:0;word-spacing:normal;background-color:#939297;">
+    <div role="article" aria-roledescription="email" lang="fr"
+    style="text-size-adjust:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;background-color:#939297;">
+        {% comment %}
+        This scaffold is necessary so that our email will be centered across all email clients.
+        We create a 100% wide table, and then set the border and border-spacing to zero.
+        Then we create a row and table cell with no padding which has align="center" set so that its contents will be centered.
+        {% endcomment %}
+        <table role="presentation" style="width:100%;border:none;border-spacing:0;">
+            <tr>
+                <td align="center" style="padding:0;">
+                {% comment %}
+                Before adding our main content container, we need to set up a Ghost Table:
+                a rigid table with a fixed width that only renders in Outlook because it’s hidden
+                inside some special Outlook-only conditional comments. We need to do this because
+                our main container is going to use the CSS max-width property, and not all versions
+                of Outlook for Windows support it. Without max-width support, the main container
+                would explode to full-width when viewed in Outlook for Windows, so we need to contain it.
+                {% endcomment %}
+                    <!--[if mso]>
+                        <table role="presentation" align="center" style="width:600px;">
+                        <tr>
+                        <td>
+                    <![endif]-->
+                        {% block email_content %}{% endblock email_content %}
+                    <!--[if mso]>
+                        </td>
+                        </tr>
+                        </table>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -1,0 +1,57 @@
+{% extends 'topicblog/base_email_client.html' %}
+{% load static %}
+{% load email_tags %}
+
+{% block email_content %}
+
+{% comment %} This table is the main container{% endcomment %}
+<table role="presentation"
+style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
+    <tr>
+        {% comment "Logo" %}This row handles the logo display{% endcomment %}
+        <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">
+            <a href="https://www.mobilitains.fr/" style="text-decoration:none;">
+                {% if logo_path %}
+                    <img src="{{ logo_path }}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% else %}
+                    <img src="{% static 'asso_tn/M-logo_colored-32.png' %}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% endif %}
+            </a>
+        </td> <!-- End Logo -->
+    </tr>
+    <tr> {% comment %} Title and Body_1 {% endcomment %}
+        <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
+            <h1 style="margin-top:0;margin-bottom:16px;font-size:26px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">
+                {{ email.title }}
+            </h1>
+            <p style="margin:0;">
+                {{ email.body_text_1_md }}
+            </p>
+        </td>
+    </tr> <!-- End of Body_1-->
+    {% if email.cta_1_slug %}
+        {% email_cta_button email.cta_1_slug email.cta_1_label %}
+    {% endif %}
+    {% if email.body_image_1 %}
+        {% email_full_width_image email.body_image_1.url email.body_image_1_alt_text %}
+    {% endif %}
+    {% email_body_text_md email.body_text_2_md %}
+    {% if email.body_image_2 %}
+        {% email_full_width_image email.body_image_2.url email.body_image_2_alt_text %}
+    {% endif %}
+    {% if  email.cta_2_slug %}
+        {% email_cta_button email.cta_2_slug email.cta_2_label %}
+    {% endif %}
+    <tr> <!-- Footer -->
+        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+            <p style="margin:0;font-size:14px;line-height:20px;">
+                &reg; Mobilitains 2022<br>
+                <a class="unsub" href="{{ unsub_link }}" style="color:#cccccc;text-decoration:underline;">Se désabonner</a>
+            </p>
+        </td>
+    </tr> <!-- End of Footer -->
+</table>
+
+{% endblock email_content %}

--- a/transport_nantes/topicblog/templates/topicblog/content_launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_launcher.html
@@ -56,7 +56,7 @@
 	    <a href="{% url 'topic_blog:view_item_by_slug' page.slug %}">
 		<div class="shadow-md">
 		    <img class="rounded"
-			 src="{{ page.launcher_image }}"
+			 src="{{ page.launcher_image.url }}"
 			 alt="{{ page.launcher_image_alt_text }}"
 			 style="width:100%">
 		</div>

--- a/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
@@ -1,0 +1,13 @@
+{% extends 'topicblog/content.html' %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+
+    <form class="col-10 mx-auto"
+    action="{% url 'topicblog:send_email' tbe_slug %}"
+    method="POST">{% csrf_token %}
+        {{form|crispy}}
+        <button type="submit" class="btn navigation-button">Envoyer</button>
+    </form>
+
+{% endblock content %}

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -1,0 +1,61 @@
+from django import template
+from django.urls import reverse_lazy
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def email_full_width_image(
+        filepath: str, alt_text: str,
+        link: str = "https://mobilitains.fr") -> str:
+    html_template = """
+    <tr>
+        <td
+        style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+            <a href="{link}" style="text-decoration:none;">
+                <img src="{filepath}" width="600" alt="{alt_text}"
+                style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+            </a>
+        </td>
+    </tr>
+    """.format(
+        filepath=filepath,
+        alt_text=alt_text,
+        link=link)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_body_text_md(text: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding:30px;background-color:#ffffff;">
+            <p style="margin:0;">
+                {text}
+            </p>
+        </td>
+    </tr>
+    """.format(text=text)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_cta_button(slug: str, label: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+        background-color:#ffffff;text-align:center;">
+            <p>
+                <a href="{slug}" class="btn
+                donation-button btn-lg">
+                {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                </a>
+            </p>
+        </td>
+    </tr>
+    """.format(
+        slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+        label=label
+        )
+    return mark_safe(html_template)

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -1,0 +1,96 @@
+from django.conf import settings
+from django.template import Template, Context
+from django.test import TestCase
+from django.urls import reverse_lazy
+
+
+class TBEmailTemplateTagsTests(TestCase):
+
+    def test_email_full_width_image(self):
+        # An existing static image
+        filepath = "asso_tn/belvederes.jpg"
+        alt_text = "Belvederes"
+        link = "https://mobilitains.fr"
+        template_string = (
+            "{% load static %}{% load email_tags %}"
+            "{% static "f"'{filepath}'"" as filepath %}"
+            "{% email_full_width_image filepath " f"'{alt_text}' '{link}'"
+            " %}")
+        context = Context()
+        rendered_template = Template(template_string).render(context)
+        # Exepcted result is from email_full_width_image's code.
+        expected_template = f"""
+        <tr>
+            <td
+            style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+                <a href="{link}" style="text-decoration:none;">
+                    <img src="{settings.STATIC_URL}{filepath}" width="600" alt="{alt_text}"
+                    style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+                </a>
+            </td>
+        </tr>
+        """.format( # noqa
+            filepath=filepath,
+            alt_text=alt_text,
+            link=link)
+
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_body_text_md(self):
+
+        text = "This is a test"
+        expected_template = \
+            f"""
+            <tr>
+                <td style="padding:30px;background-color:#ffffff;">
+                    <p style="margin:0;">
+                        {text}
+                    </p>
+                </td>
+            </tr>
+            """
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_body_text_md text %}")
+        context = Context({"text": text})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_cta_button(self):
+
+        slug = "index"
+        label = "Go to the homepage"
+        expected_template = """
+        <tr>
+            <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+            background-color:#ffffff;text-align:center;">
+                <p>
+                    <a href="{slug}" class="btn
+                    donation-button btn-lg">
+                    {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                    </a>
+                </p>
+            </td>
+        </tr>
+        """.format(
+            slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+            label=label
+        )
+
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_cta_button slug label %}")
+        context = Context({"slug": slug, "label": label})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -1,8 +1,14 @@
 from datetime import datetime, timedelta, timezone
-from django.test import TestCase, Client
-from .models import TopicBlogItem
+
 from django.contrib.auth.models import Permission, User
+from django.test import Client, TestCase
 from django.urls import reverse
+from mailing_list.models import MailingList
+from mailing_list.events import (get_subcribed_users_email_list,
+                                 unsubscribe_user_from_list,
+                                 subscribe_user_to_list)
+
+from .models import TopicBlogEmail, TopicBlogItem
 
 
 class Test(TestCase):
@@ -865,7 +871,7 @@ class TBIView(TestCase):
             - client = the client of user (auth user, unauth and staff user)
             - code = the statut code (not varie for user)
             - message = the error message (not varie for user)"""
-        
+
         self.users_expected = [
             {"client": self.client, "code": 403,
              "msg": "User with no staff status is not permited"},
@@ -912,3 +918,97 @@ class TBIView(TestCase):
         # test the result of the staff user
         self.assertJSONEqual(str(response.content, encoding='utf8'),
                              {"url": "/tb/admin/t/list/test-slug-no-alt/"})
+
+
+class TopicBlogEmailTest(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="test_user",
+            email="admin@mobilitain.fr",
+            password="test_password")
+        self.email_article = TopicBlogEmail.objects.create(
+            subject="Test subject",
+            user=self.superuser,
+            body_text_1_md="Test body text 1",
+            slug="test-email",
+            publication_date=datetime.now(timezone.utc),
+            first_publication_date=datetime.now(timezone.utc),
+            template_name="topicblog/content_email.html",
+            title="Test title")
+        self.mailing_list = MailingList.objects.create(
+            mailing_list_name="the_mailing_list_name",
+            mailing_list_token="the_mailing_list_token",
+            contact_frequency_weeks=12,
+            list_active=True)
+        self.no_permissions_user = User.objects.create_user(
+            username="user_without_permissions",
+            email="test@mobilitain.fr"
+        )
+        subscribe_user_to_list(self.superuser, self.mailing_list)
+        subscribe_user_to_list(self.no_permissions_user, self.mailing_list)
+        self.no_permissions_client = Client()
+        self.admin_client = Client()
+        self.admin_client.force_login(self.superuser)
+        self.no_permissions_client.force_login(self.no_permissions_user)
+
+        # Anonymous users are invited tol og in and from there, you
+        # land either on 403 Forbidden or 200 OK depending on the
+        # user's permissions.
+        self.perm_needed_responses = [
+            {"client": self.client, "code": 302,
+             "msg": "Anonymous users are redirected to login."},
+            {"client": self.no_permissions_client, "code": 403,
+             "msg": ("Logged in users without proper permissions can't have "
+                     "access to this page.")},
+            {"client": self.admin_client, "code": 200,
+             "msg": "The page must return 200 the user has the permission."}
+        ]
+        self.no_perm_needed_responses = [
+            {"client": self.client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."},
+            {"client": self.no_permissions_client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."},
+            {"client": self.admin_client, "code": 200,
+             "msg": "The page must return 200 independently of permissions."}
+        ]
+
+    def test_TBE_view_one_status_code(self):
+
+        for user_type in self.perm_needed_responses:
+            response = user_type["client"].get(
+                reverse('topic_blog:view_email_by_pkid',
+                        args=[self.email_article.pk, self.email_article.slug]
+                        )
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+
+    def test_TBE_view_status_code(self):
+        for user_type in self.no_perm_needed_responses:
+            response = user_type["client"].get(
+                reverse('topic_blog:view_email_by_slug',
+                        args=[self.email_article.slug]
+                        )
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+
+    def test_get_subcribed_users_email_list(self):
+
+        # superuser and no_perm_user are subscribed to the mailing list
+        # in the setUp method
+        number_of_subscribed_users = 2
+        self.assertEqual(
+            len(get_subcribed_users_email_list(self.mailing_list)),
+            number_of_subscribed_users)
+
+        # Remove superuser from subbed users of the mailing list
+        unsubscribe_user_from_list(self.superuser, self.mailing_list)
+        number_of_subscribed_users = 1
+        self.assertEqual(
+            len(get_subcribed_users_email_list(self.mailing_list)),
+            number_of_subscribed_users)
+
+        # The last email is the no_permissions_user
+        self.assertEqual(get_subcribed_users_email_list(self.mailing_list)[0],
+                         self.no_permissions_user.email)

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -19,7 +19,7 @@ from django.urls import reverse, reverse_lazy
 from asso_tn.utils import StaffRequired
 from .models import (TopicBlogItem, TopicBlogEmail, TopicBlogPress,
                      TopicBlogLauncher)
-from .forms import TopicBlogItemForm
+from .forms import TopicBlogItemForm, TopicBlogEmailSendForm
 
 logger = logging.getLogger("django")
 
@@ -432,7 +432,7 @@ class TopicBlogEmailList(PermissionRequiredMixin, TopicBlogBaseList):
 
 
 class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
-                         TemplateView):
+                         FormView):
     """Notes to Benjamin and Mickael:
 
     This view isn't implemented yet.  Here's what I think you should do:
@@ -509,7 +509,15 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
 
     """
     permission_required = 'topicblog.tbe.may_send'
-    pass
+    form_class = TopicBlogEmailSendForm
+    template_name = 'topicblog/topicblogemail_send_form.html'
+    success_url = "/"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["tbe_slug"] = self.kwargs['the_slug']
+        return context
+
 
 
 ######################################################################

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -710,8 +710,6 @@ class TopicBlogLauncherView(TopicBlogBaseView):
         context = super().get_context_data(**kwargs)
         context['context_appropriate_base_template'] = \
             'topicblog/base_launcher.html'
-        tb_object = context['page']
-        user = self.request.user
         return context
 
 

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -17,7 +17,8 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.urls import reverse, reverse_lazy
 
 from asso_tn.utils import StaffRequired
-from .models import TopicBlogItem, TopicBlogEmail, TopicBlogPress, TopicBlogLauncher
+from .models import (TopicBlogItem, TopicBlogEmail, TopicBlogPress,
+                     TopicBlogLauncher)
 from .forms import TopicBlogItemForm
 
 logger = logging.getLogger("django")
@@ -97,7 +98,7 @@ class TopicBlogBaseView(TemplateView):
             tb_object = self.model.objects.filter(
                 slug=kwargs['the_slug'],
                 publication_date__isnull=False
-                ).order_by("date_modified").last()
+            ).order_by("date_modified").last()
         except ObjectDoesNotExist:
             raise Http404("Page non trouvée")
         if tb_object is None:
@@ -336,6 +337,7 @@ class TopicBlogItemViewOnePermissions(PermissionRequiredMixin):
     Default behaviour is at class level and doesn't allow a
     per-method precision.
     """
+
     def has_permission(self) -> bool:
         user = self.request.user
         if self.request.method == 'POST':
@@ -372,6 +374,7 @@ class TopicBlogEmailViewOnePermissions(PermissionRequiredMixin):
     Default behaviour is at class level and doesn't allow a
     per-method precision.
     """
+
     def has_permission(self) -> bool:
         user = self.request.user
         if self.request.method == 'POST':
@@ -379,6 +382,7 @@ class TopicBlogEmailViewOnePermissions(PermissionRequiredMixin):
         elif self.request.method == 'GET':
             return user.has_perm('topicblog.tbe.may_view')
         return super().has_permission()
+
 
 class TopicBlogEmailEdit(PermissionRequiredMixin,
                          TopicBlogBaseEdit):
@@ -392,12 +396,13 @@ class TopicBlogEmailView(TopicBlogBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_email.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_email.html'
         tb_object = context['page']
         user = self.request.user
         if user.has_perm('topicblog.tbe.may_send_self') or \
-           (user.has_perm('topicblog.tbe.may_send') \
-            and tb_object.publisher != user):
+           (user.has_perm('topicblog.tbe.may_send')
+                and tb_object.publisher != user):
             context['sendable'] = True
         return context
 
@@ -408,7 +413,8 @@ class TopicBlogEmailViewOne(TopicBlogEmailViewOnePermissions,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_email.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_email.html'
         return context
 
 
@@ -423,6 +429,7 @@ class TopicBlogEmailList(TopicBlogBaseList):
             return ['topicblog/topicblogemail_list_one.html'] + names
         else:
             return names
+
 
 class TopicBlogEmailSend(LoginRequiredMixin, TemplateView):
     """Notes to Benjamin and Mickael:
@@ -513,6 +520,7 @@ class TopicBlogPressViewOnePermissions(PermissionRequiredMixin):
     Default behaviour is at class level and doesn't allow a
     per-method precision.
     """
+
     def has_permission(self) -> bool:
         user = self.request.user
         if self.request.method == 'POST':
@@ -520,6 +528,7 @@ class TopicBlogPressViewOnePermissions(PermissionRequiredMixin):
         elif self.request.method == 'GET':
             return user.has_perm('topicblog.tbp.may_view')
         return super().has_permission()
+
 
 class TopicBlogPressEdit(PermissionRequiredMixin,
                          TopicBlogBaseEdit):
@@ -533,12 +542,13 @@ class TopicBlogPressView(TopicBlogBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_press.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_press.html'
         tb_object = context['page']
         user = self.request.user
         if user.has_perm('topicblog.tbp.may_send_self') or \
-           (user.has_perm('topicblog.tbp.may_send') \
-            and tb_object.publisher != user):
+           (user.has_perm('topicblog.tbp.may_send')
+                and tb_object.publisher != user):
             context['sendable'] = True
         return context
 
@@ -549,7 +559,8 @@ class TopicBlogPressViewOne(TopicBlogPressViewOnePermissions,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_press.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_press.html'
         return context
 
 
@@ -565,6 +576,7 @@ class TopicBlogPressList(PermissionRequiredMixin,
             return ['topicblog/topicblogpress_list_one.html'] + names
         else:
             return names
+
 
 class TopicBlogPressSend(LoginRequiredMixin, TemplateView):
     """Notes to Benjamin and Mickael:
@@ -668,6 +680,7 @@ class TopicBlogLauncherViewOnePermissions(PermissionRequiredMixin):
     Default behaviour is at class level and doesn't allow a
     per-method precision.
     """
+
     def has_permission(self) -> bool:
         user = self.request.user
         if self.request.method == 'POST':
@@ -675,6 +688,7 @@ class TopicBlogLauncherViewOnePermissions(PermissionRequiredMixin):
         elif self.request.method == 'GET':
             return user.has_perm('topicblog.tbla.may_view')
         return super().has_permission()
+
 
 class TopicBlogLauncherEdit(PermissionRequiredMixin,
                             TopicBlogBaseEdit):
@@ -694,14 +708,15 @@ class TopicBlogLauncherView(TopicBlogBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['context_appropriate_base_template'] = 'topicblog/base_launcher.html'
+        context['context_appropriate_base_template'] = \
+            'topicblog/base_launcher.html'
         tb_object = context['page']
         user = self.request.user
         return context
 
 
 class TopicBlogLauncherViewOne(TopicBlogLauncherViewOnePermissions,
-                            TopicBlogBaseViewOne):
+                               TopicBlogBaseViewOne):
     model = TopicBlogLauncher
 
     def get_context_data(self, **kwargs):

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -387,6 +387,7 @@ class TopicBlogEmailViewOnePermissions(PermissionRequiredMixin):
 class TopicBlogEmailEdit(PermissionRequiredMixin,
                          TopicBlogBaseEdit):
     model = TopicBlogEmail
+    permission_required = 'topicblog.tbe.may_edit'
     template_name = 'topicblog/tb_item_edit.html'
     form_class = TopicBlogItemForm
 
@@ -418,20 +419,20 @@ class TopicBlogEmailViewOne(TopicBlogEmailViewOnePermissions,
         return context
 
 
-class TopicBlogEmailList(TopicBlogBaseList):
+class TopicBlogEmailList(PermissionRequiredMixin, TopicBlogBaseList):
     model = TopicBlogEmail
     permission_required = 'topicblog.tbe.may_view'
 
     def get_template_names(self):
         names = super().get_template_names()
-        print(names)
         if 'the_slug' in self.kwargs:
             return ['topicblog/topicblogemail_list_one.html'] + names
         else:
             return names
 
 
-class TopicBlogEmailSend(LoginRequiredMixin, TemplateView):
+class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
+                         TemplateView):
     """Notes to Benjamin and Mickael:
 
     This view isn't implemented yet.  Here's what I think you should do:
@@ -507,6 +508,7 @@ class TopicBlogEmailSend(LoginRequiredMixin, TemplateView):
              already set (and call unsubscribe_user_from_list()).
 
     """
+    permission_required = 'topicblog.tbe.may_send'
     pass
 
 
@@ -533,6 +535,7 @@ class TopicBlogPressViewOnePermissions(PermissionRequiredMixin):
 class TopicBlogPressEdit(PermissionRequiredMixin,
                          TopicBlogBaseEdit):
     model = TopicBlogPress
+    permission_required = 'topicblog.tbp.may_edit'
     template_name = 'topicblog/tb_item_edit.html'
     form_class = TopicBlogItemForm
 
@@ -571,14 +574,14 @@ class TopicBlogPressList(PermissionRequiredMixin,
 
     def get_template_names(self):
         names = super().get_template_names()
-        print(names)
         if 'the_slug' in self.kwargs:
             return ['topicblog/topicblogpress_list_one.html'] + names
         else:
             return names
 
 
-class TopicBlogPressSend(LoginRequiredMixin, TemplateView):
+class TopicBlogPressSend(PermissionRequiredMixin, LoginRequiredMixin,
+                         TemplateView):
     """Notes to Benjamin and Mickael:
 
     This view isn't implemented yet.  Here's what I think you should do:
@@ -667,6 +670,7 @@ class TopicBlogPressSend(LoginRequiredMixin, TemplateView):
              some day have lists for those.
 
     """
+    permission_required = 'topicblog.tbp.may_send'
     pass
 
 
@@ -693,6 +697,7 @@ class TopicBlogLauncherViewOnePermissions(PermissionRequiredMixin):
 class TopicBlogLauncherEdit(PermissionRequiredMixin,
                             TopicBlogBaseEdit):
     model = TopicBlogLauncher
+    permission_required = 'topicblog.tbla.may_edit'
     template_name = 'topicblog/tb_launcher_edit.html'
     form_class = TopicBlogItemForm
 
@@ -722,13 +727,12 @@ class TopicBlogLauncherViewOne(TopicBlogLauncherViewOnePermissions,
         return context
 
 
-class TopicBlogLauncherList(TopicBlogBaseList):
+class TopicBlogLauncherList(PermissionRequiredMixin, TopicBlogBaseList):
     model = TopicBlogLauncher
     permission_required = 'topicblog.tbla.may_view'
 
     def get_template_names(self):
         names = super().get_template_names()
-        print(names)
         if 'the_slug' in self.kwargs:
             return ['topicblog/topicbloglauncher_list_one.html'] + names
         else:


### PR DESCRIPTION
This is very WIP but here is where I stand with this PR : 


> 1.  On GET, display a form.  That form should (for now) just show
the mailing_lists available in a dropdown list and let the user
choose one.  Once a mailing_list is chosen, enable a send button.
Pushing the send button will POST to the same url.

GET on the send URL will display a drop-down with all our mailing lists as described there 

>2.  On POST, send the mail.  This means you do the following:
    (i)  Get the list of users from the mailing_list by calling
         subscribed_users() from mailing_list/events.py.  Note that
         that function doesn't exist yet, but it should be a really,
         really simple function for you to write based on the other
         functions in the file.  You should make a single commit
         with that function and tests for that function.

This is done, I created a function `get_subcribed_users_email_list` for this purpose, alongside its tests.

> (ii) For each user in the list:
Compute a timed_token (function already exists,
make_timed_token() in asso_tn/utils.py).  Given it a
three-week timeout so as not to over-think.  Pass the
TopicBlogEmailSendRecord pk_id in persistent. 

This is @mcmikashi 's PR #517, so while this isn't merged, I started to create a function `_set_email_context` which I plan to make set the context, meaning the unsubscribe link at first and any other useful context variable. Because it's not finished yet, I set context in the `prepare_email` function for now.

> In the footer of the
base email template (note: this is 30 seconds, you just
write "<div><div><p><a href={% url
... %}>unsubscribe</a></div></div>" with maybe some
arguments to the divs and such.  DO NOT spend time now
fiddling with making it look just right.  There's a
difference between unworldly user interaction paradigms
and simply not being pretty yet.  The latter is easily
remedied in a second commit, the former is trickier.
This is a commit.

I happen to have already created a template that has a placeholder for the unsubscribe link : 
![image](https://user-images.githubusercontent.com/70256364/157284051-0286f382-0fff-4052-85ec-3614ed3144d8.png)

So once the function to have an unsubscribe link will be up, I'll be able to replace it in context.

>  Also compute the url (the path already exists) to view
this email on the web.  Put that in the context, too, and
make sure you add a link at the top of the email base
template, just above the content.  That's another commit.

This isn't integrated, both backend and template. It's TODO.

>Render the email, pass it off to SES for sending, and
write a record to TopicBlogEmailSendRecord.  This is
another commit.

I currently pass the email to SES and it gets send, but the TBESendRecord isn't created yet. TODO

All the rest isn't started yet.

I do have a question for @JeffAbrahamson , in your PR you created a lot of templates (base_xxx, content_xxx), I'm not sure about why we need a base_email and a content_email yet, I added the two templates needed to display in may clients, but the e/view/<slug> will display like a normal TBItem, I think. 

