### PR TITLE
Fix GitHub Action module import error

### DIFF
--- a/transport_nantes/asso_tn/templatetags/don.py
+++ b/transport_nantes/asso_tn/templatetags/don.py
@@ -1,10 +1,10 @@
 from django import template
 from django.utils.safestring import mark_safe
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 
 register = template.Library()
 
-page_donation = reverse("stripe_app:stripe")
+page_donation = reverse_lazy("stripe_app:stripe")
 
 
 @register.simple_tag


### PR DESCRIPTION
Several things happen here :
- test_tn_links is ran by the test suite
- Among the imports, we have `from asso_tn.templatetags import don`
- don.py is subsequently imported
- In the very first lines, a global variable is created for the
templatetags to use : page_donation = reverse("stripe_app:stripe")
- Because don.py is ran, page_donation is evaluated.
- The reverse function is ran, which, in turn, calls the urlconf and a
resolver function.
- The resolver will check the root url_conf in transport_nantes/urls.py
- The urls.py is ran, in it we import
`from topicblog.views import TopicBlogItemView`
- topicblog/views.py is executed
- Inside it, we import among other things :
from .forms import TopicBlogItemForm, TopicBlogEmailSendForm
- topicblog/forms.py is executed
- In TopicBlogEmailSendForm, we query MailingList.objects.all()
- The reason why it fails is unclear, maybe the test database isn't set
at this point of the test, and moving the import of  `don` in a test
function didn't help.
- To prevent the whole thing from unrolling, my best call was to make
the reverse lazy. The page_donation not being evaluated, the reverse
wont import all subsequent files and wont fail the test.

Aside, I'm adding `__init__.py` file to mailing_list.templatetags for it
to be detected as a module by linters.