### PR TITLE
Tbe view templates 532

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/base_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_email_client.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="https://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="x-apple-disable-message-reformatting">
+    <title></title>
+    {% comment %}
+        Some CSS and PNG sizing resets for Microsoft Outlook on Windows
+        hidden inside conditional comments (the <!--[if mso]> bits)
+        src : https://webdesign.tutsplus.com/articles/creating-a-simple-responsive-html-email--webdesign-12978
+    {% endcomment %}
+    <!--[if mso]>
+    <style>
+        table {border-collapse:collapse;border-spacing:0;border:none;margin:0;}
+        div, td {padding:0;}
+        div {margin:0 !important;}
+    </style>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+    <style>
+        table, td, div, h1, p {
+            font-family: Arial, sans-serif;
+        }
+        @media screen and (max-width: 530px) {
+            .unsub {
+                display: block;
+                padding: 8px;
+                margin-top: 14px;
+                border-radius: 6px;
+                background-color: #555555;
+                text-decoration: none !important;
+                font-weight: bold;
+            }
+            .col-lge {
+                max-width: 100% !important;
+            }
+        }
+        @media screen and (min-width: 531px) {
+            .col-sml {
+                max-width: 27% !important;
+            }
+            .col-lge {
+                max-width: 73% !important;
+            }
+        }
+        a:link.donation-button {
+            color: white;
+            font-weight: 600;
+            background-color: #5BC2E7;
+            border-radius: 0;
+        }
+        a:visited.donation-button {
+            color: white;
+        }
+        a:hover.donation-button {
+            color: white;
+        }
+        .donation-button {
+            background-color: #5BC2E7;
+            color:white;
+            font-weight: 600;
+        }
+        .btn.donation-button:hover {
+            color:white;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 400;
+            color: #212529;
+            text-align: center;
+            vertical-align: middle;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            background-color: transparent;
+            border: 1px solid transparent;
+            padding: .375rem .75rem;
+            font-size: 1rem;
+            line-height: 1.5;
+            border-radius: .25rem;
+            transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+            text-decoration: none;
+        }
+    </style>
+    <script src="https://kit.fontawesome.com/46b82563d9.js" crossorigin="anonymous"></script>
+</head>
+<body style="margin:0;padding:0;word-spacing:normal;background-color:#939297;">
+    <div role="article" aria-roledescription="email" lang="fr"
+    style="text-size-adjust:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;background-color:#939297;">
+        {% comment %}
+        This scaffold is necessary so that our email will be centered across all email clients.
+        We create a 100% wide table, and then set the border and border-spacing to zero.
+        Then we create a row and table cell with no padding which has align="center" set so that its contents will be centered.
+        {% endcomment %}
+        <table role="presentation" style="width:100%;border:none;border-spacing:0;">
+            <tr>
+                <td align="center" style="padding:0;">
+                {% comment %}
+                Before adding our main content container, we need to set up a Ghost Table:
+                a rigid table with a fixed width that only renders in Outlook because it’s hidden
+                inside some special Outlook-only conditional comments. We need to do this because
+                our main container is going to use the CSS max-width property, and not all versions
+                of Outlook for Windows support it. Without max-width support, the main container
+                would explode to full-width when viewed in Outlook for Windows, so we need to contain it.
+                {% endcomment %}
+                    <!--[if mso]>
+                        <table role="presentation" align="center" style="width:600px;">
+                        <tr>
+                        <td>
+                    <![endif]-->
+                        {% block email_content %}{% endblock email_content %}
+                    <!--[if mso]>
+                        </td>
+                        </tr>
+                        </table>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/transport_nantes/topicblog/templates/topicblog/content_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email.html
@@ -45,13 +45,13 @@
           <p class="hero-description">{{ page.header_description }}</p>
      </div>
 </div>
-     <div id="app_content" class="d-flex flex-column col-sm-12 col-md-10 col-lg-9 m-auto">
+     <div id="app_content" class="d-flex flex-column col-sm-12 col-md-10 col-lg-9 mx-auto mt-5">
           {% tn_markdown page.body_text_1_md %}
           {% if page.cta_1_slug|length > 0 %}
                <a href="{% url 'topic_blog:view_item_by_slug' page.cta_1_slug %}"
 		  class="btn donation-button my-3 centered-inline-button">
 		   {{ page.cta_1_label }}
-		   <i class="fa fa-arrow-right"" aria-hidden="true"></i>
+		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
 	       </a>
           {% endif %}
           {# Body image, if any #}

--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -1,0 +1,57 @@
+{% extends 'topicblog/base_email_client.html' %}
+{% load static %}
+{% load email_tags %}
+
+{% block email_content %}
+
+{% comment %} This table is the main container{% endcomment %}
+<table role="presentation"
+style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
+    <tr>
+        {% comment "Logo" %}This row handles the logo display{% endcomment %}
+        <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">
+            <a href="https://www.mobilitains.fr/" style="text-decoration:none;">
+                {% if logo_path %}
+                    <img src="{{ logo_path }}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% else %}
+                    <img src="{% static 'asso_tn/M-logo_colored-32.png' %}" width="165" alt="Logo Mobilitains"
+                    style="width:165px;max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">
+                {% endif %}
+            </a>
+        </td> <!-- End Logo -->
+    </tr>
+    <tr> {% comment %} Title and Body_1 {% endcomment %}
+        <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
+            <h1 style="margin-top:0;margin-bottom:16px;font-size:26px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">
+                {{ email.title }}
+            </h1>
+            <p style="margin:0;">
+                {{ email.body_text_1_md }}
+            </p>
+        </td>
+    </tr> <!-- End of Body_1-->
+    {% if email.cta_1_slug %}
+        {% email_cta_button email.cta_1_slug email.cta_1_label %}
+    {% endif %}
+    {% if email.body_image_1 %}
+        {% email_full_width_image email.body_image_1.url email.body_image_1_alt_text %}
+    {% endif %}
+    {% email_body_text_md email.body_text_2_md %}
+    {% if email.body_image_2 %}
+        {% email_full_width_image email.body_image_2.url email.body_image_2_alt_text %}
+    {% endif %}
+    {% if  email.cta_2_slug %}
+        {% email_cta_button email.cta_2_slug email.cta_2_label %}
+    {% endif %}
+    <tr> <!-- Footer -->
+        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+            <p style="margin:0;font-size:14px;line-height:20px;">
+                &reg; Mobilitains 2022<br>
+                <a class="unsub" href="{{ unsub_link }}" style="color:#cccccc;text-decoration:underline;">Se désabonner</a>
+            </p>
+        </td>
+    </tr> <!-- End of Footer -->
+</table>
+
+{% endblock email_content %}

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -1,0 +1,61 @@
+from django import template
+from django.urls import reverse_lazy
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def email_full_width_image(
+        filepath: str, alt_text: str,
+        link: str = "https://mobilitains.fr") -> str:
+    html_template = """
+    <tr>
+        <td
+        style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+            <a href="{link}" style="text-decoration:none;">
+                <img src="{filepath}" width="600" alt="{alt_text}"
+                style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+            </a>
+        </td>
+    </tr>
+    """.format(
+        filepath=filepath,
+        alt_text=alt_text,
+        link=link)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_body_text_md(text: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding:30px;background-color:#ffffff;">
+            <p style="margin:0;">
+                {text}
+            </p>
+        </td>
+    </tr>
+    """.format(text=text)
+    return mark_safe(html_template)
+
+
+@register.simple_tag
+def email_cta_button(slug: str, label: str) -> str:
+    html_template = """
+    <tr>
+        <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+        background-color:#ffffff;text-align:center;">
+            <p>
+                <a href="{slug}" class="btn
+                donation-button btn-lg">
+                {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                </a>
+            </p>
+        </td>
+    </tr>
+    """.format(
+        slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+        label=label
+        )
+    return mark_safe(html_template)

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -1,0 +1,96 @@
+from django.conf import settings
+from django.template import Template, Context
+from django.test import TestCase
+from django.urls import reverse_lazy
+
+
+class TBEmailTemplateTagsTests(TestCase):
+
+    def test_email_full_width_image(self):
+        # An existing static image
+        filepath = "asso_tn/belvederes.jpg"
+        alt_text = "Belvederes"
+        link = "https://mobilitains.fr"
+        template_string = (
+            "{% load static %}{% load email_tags %}"
+            "{% static "f"'{filepath}'"" as filepath %}"
+            "{% email_full_width_image filepath " f"'{alt_text}' '{link}'"
+            " %}")
+        context = Context()
+        rendered_template = Template(template_string).render(context)
+        # Exepcted result is from email_full_width_image's code.
+        expected_template = f"""
+        <tr>
+            <td
+            style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
+                <a href="{link}" style="text-decoration:none;">
+                    <img src="{settings.STATIC_URL}{filepath}" width="600" alt="{alt_text}"
+                    style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+                </a>
+            </td>
+        </tr>
+        """.format( # noqa
+            filepath=filepath,
+            alt_text=alt_text,
+            link=link)
+
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_body_text_md(self):
+
+        text = "This is a test"
+        expected_template = \
+            f"""
+            <tr>
+                <td style="padding:30px;background-color:#ffffff;">
+                    <p style="margin:0;">
+                        {text}
+                    </p>
+                </td>
+            </tr>
+            """
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_body_text_md text %}")
+        context = Context({"text": text})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+        self.assertEqual(rendered_template, expected_template)
+
+    def test_email_cta_button(self):
+
+        slug = "index"
+        label = "Go to the homepage"
+        expected_template = """
+        <tr>
+            <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
+            background-color:#ffffff;text-align:center;">
+                <p>
+                    <a href="{slug}" class="btn
+                    donation-button btn-lg">
+                    {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
+                    </a>
+                </p>
+            </td>
+        </tr>
+        """.format(
+            slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
+            label=label
+        )
+
+        template_string = (
+            "{% load email_tags %}"
+            "{% email_cta_button slug label %}")
+        context = Context({"slug": slug, "label": label})
+        rendered_template = Template(template_string).render(context)
+        # Get rid of the whitespaces
+        rendered_template = " ".join(rendered_template.split())
+        expected_template = " ".join(expected_template.split())
+
+        self.assertEqual(rendered_template, expected_template)

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -416,6 +416,7 @@ class TopicBlogEmailViewOne(TopicBlogEmailViewOnePermissions,
         context = super().get_context_data(**kwargs)
         context['context_appropriate_base_template'] = \
             'topicblog/base_email.html'
+        self.template_name = 'topicblog/content_email.html'
         return context
 
 


### PR DESCRIPTION
We're going to use 2 sorts of templates to display TBEmails:
- One to be displayed in mail clients, which heavily relies on inline
styles and HTML tables
- One to be displayed on our website, with a more article looking way,
that will allow the user to browse the website normally.

The 1st kind is introduced with these commits, and the 2nd has already been added in #529, and updated here to fit the current implementation of TBEmails.

On the note of templatetags, it's true that for now, one might not be able to use all those available for TBItem (mostly thinking about custom markdown ones like `[[verb]]((arg))`) although I haven't tried to display them to see how it reacts.
So far I've provided fields that I know will display properly in both templates, but lack of freedom in the _md fields.

I think we could make it better by either providing alternatives of processing the markdown in different ways depending on what's the purpose : `[[CTA: "Je signe"]]((the-slug))` would produce different results depending if we are rendering a mail or a classic content.
