### PR TITLE
Tbe send implementation 532

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -7,6 +7,10 @@
 {% comment %} This table is the main container{% endcomment %}
 <table role="presentation"
 style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
+    <tr style="padding:30px;text-align:center;background-color:#404040;color:#cccccc;">
+        {# links will need to be wrapped into redirect links #}
+        <a href="{{ request.scheme }}://{{ host }}{% url 'topicblog:view_email_by_slug' page.slug|default:email.slug %}" style="font-size:0.7em;color:#cccccc;text-decoration:underline;">Voir sur le site web</a>
+    </tr>
     <tr>
         {% comment "Logo" %}This row handles the logo display{% endcomment %}
         <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">

--- a/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
@@ -7,7 +7,7 @@
     action="{% url 'topicblog:send_email' tbe_slug %}"
     method="POST">{% csrf_token %}
         {{form|crispy}}
-        <button type="submit" class="btn navigation-button">Envoyer</button>
+        <button name="send-to-mailing-list" type="submit" class="btn navigation-button">Envoyer</button>
     </form>
 
 {% endblock content %}

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -1012,3 +1012,12 @@ class TopicBlogEmailTest(TestCase):
         # The last email is the no_permissions_user
         self.assertEqual(get_subcribed_users_email_list(self.mailing_list)[0],
                          self.no_permissions_user.email)
+
+    def test_tbe_send_form_status_code(self):
+        url = reverse('topic_blog:send_email',
+                      args=[self.email_article.slug])
+
+        for user_type in self.perm_needed_responses:
+            response = user_type["client"].get(url)
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -1,12 +1,15 @@
 from collections import Counter
 from datetime import datetime, timezone
 import logging
+from django.conf import settings
+from django.core import mail
 
 from django.db.models import Count, Max
 from django.http import Http404, HttpResponseServerError
 from django.http import HttpResponseRedirect
 from django.http.response import JsonResponse
 from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
 from django.contrib.auth.mixins import (LoginRequiredMixin,
                                         PermissionRequiredMixin)
 from django.contrib.auth.models import User
@@ -15,8 +18,11 @@ from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.urls import reverse, reverse_lazy
+from django.utils.html import strip_tags
 
 from asso_tn.utils import StaffRequired
+from mailing_list.events import get_subcribed_users_email_list
+from mailing_list.models import MailingList
 from .models import (TopicBlogItem, TopicBlogEmail, TopicBlogPress,
                      TopicBlogLauncher)
 from .forms import TopicBlogItemForm, TopicBlogEmailSendForm
@@ -512,13 +518,159 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
     permission_required = 'topicblog.tbe.may_send'
     form_class = TopicBlogEmailSendForm
     template_name = 'topicblog/topicblogemail_send_form.html'
+    # For now, successfully sending an email will redirect to the
+    # homepage. We'll probably want to redirect to the email
+    # itself eventually, or on the dashboard ?
     success_url = "/"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        # The slug is then used to get the TBEmail we want to send.
         context["tbe_slug"] = self.kwargs['the_slug']
         return context
 
+    def get_last_published_email(self, tbe_slug: str) -> TopicBlogEmail:
+        """Get the TBEmail object with the most recent publication date
+        for a given slug.
+        """
+        tbe_object = TopicBlogEmail.objects.filter(
+            slug=tbe_slug,
+            # Not implemented yet, but a published TBEmail should be
+            # the only one with a publication date. For now it picks the
+            # most recent.
+            publication_date__isnull=False
+            )
+        if len(tbe_object) > 1:
+            raise ValueError(
+                "There is more than one TBEmail with slug {} and a not-null "
+                "publication date".format(
+                    tbe_slug))
+        elif len(tbe_object) == 0:
+            raise ValueError(
+                "There is no TBEmail with slug {} and a not-null "
+                "publication date".format(
+                    tbe_slug))
+        return tbe_object[0]
+
+    def form_valid(self, form):
+        tbe_slug = self.kwargs['the_slug']
+        tbe_object = self.get_last_published_email(tbe_slug)
+
+        if tbe_object is None:
+            logger.info(f"No published TBEmail object found for '{tbe_slug}'")
+            raise Http404(
+                f"Pas d'email publié trouvé pour le slug '{tbe_slug}'")
+
+        mailing_list_token = form.cleaned_data['mailing_list']
+        # The recipient list is extracted from the selected MailingList.
+        mailing_list = MailingList.objects.get(
+            mailing_list_token=mailing_list_token)
+        mailing_list: MailingList
+        recipient_list = get_subcribed_users_email_list(mailing_list)
+
+        # We create and send an email for each recipient, each with
+        # custom informations (like the unsubscribe link).
+        for recipient in recipient_list:
+            custom_email = self.prepare_email(
+                pkid=tbe_object.id,
+                the_slug=tbe_slug,
+                recipient=[recipient],
+                mailing_list=mailing_list,)
+
+            logger.info(f"Successfully prepared email to {recipient}")
+            custom_email.send(fail_silently=False)
+            logger.info(f"Successfully sent email to {recipient}")
+            self.create_send_record()  # Not implemented yet
+
+        return super().form_valid(form)
+
+    def prepare_email(self, pkid: int, the_slug: str, recipient: list,
+                      mailing_list: MailingList) \
+            -> mail.EmailMultiAlternatives:
+        """
+        Creates a sendable email object from a TBEmail with a mail
+        client-friendly template, given a pkid, a slug and a mail adress.
+        """
+        if pkid < 0 or the_slug is None:
+            logger.info(f"pkid < 0 ({pkid}) or slug is none ({the_slug})")
+            return HttpResponseServerError()
+
+        # Preparing the email
+        tb_email = TopicBlogEmail.objects.get(pk=pkid, slug=the_slug)
+        self.template_name = tb_email.template_name
+        # The context statements will be moved to a _set_context method
+        # once all the features are implemented.
+        context = dict()
+        context["context_appropriate_base_template"] = \
+            "topicblog/base_email.html"
+        context["email"] = tb_email
+
+        try:
+            email = self._create_email_object(tb_email, context, recipient)
+        except Exception as e:
+            logger.info(
+                f"Error while creating EmailMultiAlternatives object: {e}")
+            raise Exception(
+                f"Error while creating EmailMultiAlternatives object: {e}")
+
+        return email
+
+    def _create_email_object(self, tb_email: TopicBlogEmail, context: dict,
+                             recipient_list: list,
+                             from_email: str = settings.DEFAULT_FROM_EMAIL) \
+            -> mail.EmailMultiAlternatives:
+        """
+        To send emails to multiple persons, django send_mail function isn't
+        enough, we need to create a EmailMultiAlternatives object to be able,
+        for example to put recipients in BCC field or add attachments.
+        It also improves the performances by reusing the same connexion to SMTP
+        server.
+        Doc :
+        https://docs.djangoproject.com/en/3.2/topics/email/#sending-multiple-emails
+        https://docs.djangoproject.com/en/3.2/topics/email/#emailmessage-objects
+        https://docs.djangoproject.com/en/3.2/topics/email/#sending-alternative-content-types
+        """
+        # HTML message is the one displayed in mail client
+        html_message = render_to_string(
+            tb_email.template_name, context=context)
+        # In cases where the HTML message isn't accepted, a plain text
+        # message is displayed in the mail client.
+        plain_text_message = strip_tags(html_message)
+
+        email = mail.EmailMultiAlternatives(
+            subject=tb_email.subject,
+            body=plain_text_message,
+            from_email=from_email,
+            to=recipient_list,
+        )
+        email.attach_alternative(html_message, "text/html")
+
+        return email
+
+    def _set_email_context(self, recipient: list, mailing_list: MailingList,
+                           slug: str) -> dict:
+        """
+        Sets the context for the email to be sent.
+        """
+        context = dict()
+        context["context_appropriate_base_template"] = \
+            "topicblog/base_email.html"
+        context["host"] = get_current_site(self.request).domain
+        # TODO: create a unsub link
+        # args = (recipient, slug, mailing_list)  # TODO: Add missing args
+        # The make_timed_token function isn't ready yet (10/3/22)
+        # context["unsub_link"] = make_timed_token(*args)
+
+        # TODO: Create a template tag to have redirect links embedded in the
+        # email.
+
+        return context
+
+    def create_send_record(self, *args):
+        """
+        Create a new TBEmailSentRecord object.
+        """
+        pass
 
 
 ######################################################################

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -13,6 +13,7 @@ from django.template.loader import render_to_string
 from django.contrib.auth.mixins import (LoginRequiredMixin,
                                         PermissionRequiredMixin)
 from django.contrib.auth.models import User
+from django.contrib.sites.shortcuts import get_current_site
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
@@ -405,6 +406,7 @@ class TopicBlogEmailView(TopicBlogBaseView):
         context = super().get_context_data(**kwargs)
         context['context_appropriate_base_template'] = \
             'topicblog/base_email.html'
+        self.template_name = 'topicblog/content_email.html'
         tb_object = context['page']
         user = self.request.user
         if user.has_perm('topicblog.tbe.may_send_self') or \
@@ -604,6 +606,8 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
         context["context_appropriate_base_template"] = \
             "topicblog/base_email.html"
         context["email"] = tb_email
+        hostname = get_current_site(self.request).domain
+        context["host"] = hostname
 
         try:
             email = self._create_email_object(tb_email, context, recipient)
@@ -632,7 +636,7 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
         """
         # HTML message is the one displayed in mail client
         html_message = render_to_string(
-            tb_email.template_name, context=context)
+            tb_email.template_name, context=context, request=self.request)
         # In cases where the HTML message isn't accepted, a plain text
         # message is displayed in the mail client.
         plain_text_message = strip_tags(html_message)


### PR DESCRIPTION
Based on PR #544

This PR is to be examinated once the #544 is merged, in that sense the actual "first" commit to review here is 9d4c5a18f9545d7cfd542ea3abf022f24a98a73f , as the previous ones are in the #544

This PR adds the possibility to send TBEmails objects by email to a mailing list, and the "view on the web" link in the Email version.
I've left some room to later add the tokenized links to unsubscribe, as it's currently in review in #517.

This is the first iteration of the Email object creation, as we want it to bring beacons and create TBEmailSentRecords, this version is sort of a MVP : Sends an email to a mailing list, with an article inside it that displays properly. 

The recipients don't have the other's recipients mails. 