### PR TITLE
Add edit and add for Topicblog Press

### DIFF
--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.forms import ModelForm
-from .models import TopicBlogItem, TopicBlogLauncher, TopicBlogEmail, TopicBlogPress
+from .models import (TopicBlogItem, TopicBlogLauncher,
+                     TopicBlogEmail, TopicBlogPress)
 from mailing_list.models import MailingList
 
 
@@ -134,6 +135,7 @@ class TopicBlogEmailForm(ModelForm):
         self.fields['template_name'] = forms.ChoiceField(
             choices=template_list,
             initial=self.instance.template_name)
+
 
 class TopicBlogPressForm(ModelForm):
     """

--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms import ModelForm
-from .models import TopicBlogItem, TopicBlogLauncher, TopicBlogEmail
+from .models import TopicBlogItem, TopicBlogLauncher, TopicBlogEmail, TopicBlogPress
 from mailing_list.models import MailingList
 
 
@@ -119,6 +119,40 @@ class TopicBlogEmailForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.instance: TopicBlogLauncher
+
+        def get_template_list(self) -> list:
+
+            templates = self.instance.template_config
+            template_list = \
+                [(None, "Selectionnez un template ...")]
+            for template, value in templates.items():
+                template_list.append((template, value["user_template_name"]))
+
+            return template_list
+
+        template_list = get_template_list(self)
+        self.fields['template_name'] = forms.ChoiceField(
+            choices=template_list,
+            initial=self.instance.template_name)
+
+class TopicBlogPressForm(ModelForm):
+    """
+    Generates a form to create and edit TopicsBlog Press objects.
+    """
+
+    class Meta:
+        model = TopicBlogPress
+        # Admins can still edit those values
+        exclude = ('first_publication_date', 'publisher', 'user',
+                   'publication_date')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.instance: TopicBlogLauncher
+
+        # When an item is published, its slug becomes frozen (unmodifiable).
+        if self.instance.publication_date:
+            self.fields['slug'].widget.attrs['readonly'] = True
 
         def get_template_list(self) -> list:
 

--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -770,6 +770,42 @@ class TopicBlogPress(TopicBlogObjectSocialBase):
             ("tbp.may_send_self", "May send own TopicBlogPress"),
         )
 
+    template_config_default = {
+        "optional_fields_for_publication": (
+            'header_image', 'header_description',
+            'body_image', 'body_image_alt_text',
+            'twitter_title', 'twitter_description',
+            'twitter_image', 'og_title',
+            'og_description', 'og_image'
+        ),
+        "one_of_fields_for_publication": [
+            ['header_title', 'header_description'],
+        ],
+        # Dependent fields: if one in a group is provided, the others must
+        # be as well before we can publish.
+        "dependent_field_names": [
+            ['body_image_1', 'body_image_1_alt_text'],
+        ],
+    }
+    template_config = {
+        'topicblog/content_press.html': {
+            'user_template_name': 'Classic',
+            'active': True,
+            "fields": {
+                'slug': True,
+                'title': True,
+                'subject': True,
+                'body_text_1_md': True,
+            },
+            "optional_fields_for_publication":
+                template_config_default['optional_fields_for_publication'],
+            "one_of_fields_for_publication":
+                template_config_default['one_of_fields_for_publication'],
+            "dependent_field_names":
+                template_config_default['dependent_field_names'],
+        },
+    }
+
     subject = models.CharField(max_length=80, blank=True)
     header_image = models.ImageField(
         upload_to='header/', blank=True,

--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -156,6 +156,7 @@ class TopicBlogObjectBase(models.Model):
 
         return image_fields
 
+
 class TopicBlogObjectSocialBase(TopicBlogObjectBase):
 
     """
@@ -273,29 +274,29 @@ class TopicBlogItem(TopicBlogObjectSocialBase):
     # Default values for template_config ###########################
     template_config_default = {
         "optional_fields_for_publication": (
-                'header_image', 'header_description',
-                'cta_1_slug', 'cta_1_label',
-                'cta_2_slug', 'cta_2_label',
-                'cta_3_slug', 'cta_3_label',
-                'body_image', 'body_image_alt_text',
-                'twitter_title', 'twitter_description',
-                'twitter_image', 'og_title',
-                'og_description', 'og_image'
-            ),
+            'header_image', 'header_description',
+            'cta_1_slug', 'cta_1_label',
+            'cta_2_slug', 'cta_2_label',
+            'cta_3_slug', 'cta_3_label',
+            'body_image', 'body_image_alt_text',
+            'twitter_title', 'twitter_description',
+            'twitter_image', 'og_title',
+            'og_description', 'og_image'
+        ),
         # Fields that, if required for publication, the requirement is
         # satisfied by providing any one of them.
         "one_of_fields_for_publication": [
-                ['body_text_1_md', 'body_text_2_md', 'body_text_3_md'],
-                ['header_title', 'header_description'],
-            ],
+            ['body_text_1_md', 'body_text_2_md', 'body_text_3_md'],
+            ['header_title', 'header_description'],
+        ],
         # Dependent fields: if one in a group is provided, the others must
         # be as well before we can publish.
         "dependent_field_names": [
-                ['cta_1_slug', 'cta_1_label'],
-                ['cta_2_slug', 'cta_2_label'],
-                ['cta_3_slug', 'cta_3_label'],
-                ['body_image', 'body_image_alt_text'],
-            ],
+            ['cta_1_slug', 'cta_1_label'],
+            ['cta_2_slug', 'cta_2_label'],
+            ['cta_3_slug', 'cta_3_label'],
+            ['body_image', 'body_image_alt_text'],
+        ],
     }
     template_config = {
         'topicblog/content.html': {
@@ -553,7 +554,6 @@ class TopicBlogItem(TopicBlogObjectSocialBase):
                 slug_fields.append(field.name)
 
         return slug_fields
-
 
 
 ######################################################################

--- a/transport_nantes/topicblog/templates/topicblog/content_press.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press.html
@@ -47,27 +47,11 @@
 </div>
      <div id="app_content" class="d-flex flex-column col-sm-12 col-md-10 col-lg-9 m-auto">
           {% tn_markdown page.body_text_1_md %}
-          {% if page.cta_1_slug|length > 0 %}
-               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_1_slug %}"
-		  class="btn donation-button my-3 centered-inline-button">
-		   {{ page.cta_1_label }}
-		   <i class="fa fa-arrow-right"" aria-hidden="true"></i>
-	       </a>
-          {% endif %}
           {# Body image, if any #}
-          {% if page.body_image|length > 0 %}
-               <img src="{{ page.body_image.url }}"
-                    alt="{{ page.body_image_alt_text }}"
+          {% if page.body_image_1 %}
+               <img src="{{ page.body_image_1.url }}"
+                    alt="{{ page.body_image_1_alt_text }}"
                     class="w-100 my-4">
-          {% endif %}
-          {# Second part, if any. #}
-          {% tn_markdown page.body_text_2_md %}
-          {% if page.cta_2_slug|length > 0 %}
-               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_2_slug %}"
-		  class="btn donation-button my-3 centered-inline-button ">
-		   {{ page.cta_2_label }}
-		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
-	       </a>
           {% endif %}
      </div>
 </div>

--- a/transport_nantes/topicblog/templates/topicblog/tb_press_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/tb_press_edit.html
@@ -1,0 +1,69 @@
+{% extends 'asso_tn/base_mobilitain.html' %}
+{% load crispy_forms_tags %}
+{% block app_content %}
+<div class="d-flex col-12 col-sm-10 col-lg-8 flex-column justify-content-center mx-auto">
+    <form id="edition_form" class="d-flex flex-column justify-content-center" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+	<div class="container">
+	  <ul class="nav nav-tabs" role="tablist">
+	    <li class="nav-item">
+	      <a class="nav-link active" data-toggle="tab" href="#form_admin">Admin</a>
+	    </li>
+	    <li class="nav-item">
+	      <a class="nav-link" data-toggle="tab" href="#form_social">Social</a>
+	    </li>
+		<li class="nav-item">
+	      <a class="nav-link" data-toggle="tab" href="#form_notes">Notes</a>
+	    </li>
+	  </ul>
+	  <!-- Tab panes -->
+	  <div class="tab-content">
+	    <div id="form_admin" class="container tab-pane active"><br>
+			{% for field in form %}
+				{% if field.name in form_admin %}
+						<div class="fieldWrapper">
+							{{ field.errors }}
+							{{ field|as_crispy_field }}
+							{% comment %}{% if field.help_text %}
+								<p class="help">{{ field.help_text|safe }}</p>
+							{% endif %}{% endcomment %}
+						</div>
+				{% endif %}
+			{% endfor %}
+	    </div>
+	    <div id="form_social" class="container tab-pane fade"><br>
+			{% for field in form %}
+				{% if field.name in form_social %}
+					<div class="fieldWrapper">
+						{{ field.errors }}
+						{{ field|as_crispy_field }}
+						{% comment %}{% if field.help_text %}
+							<p class="help">{{ field.help_text|safe }}</p>
+						{% endif %}{% endcomment %}
+					</div>
+				{% endif %}
+			{% endfor %}
+	    </div>
+		<div id="form_notes" class="container tab-pane fade"><br>
+			{% for field in form %}
+				{% if field.name in form_notes %}
+					<div class="fieldWrapper">
+						{{ field.errors }}
+						{{ field|as_crispy_field }}
+						{% comment %}{% if field.help_text %}
+							<p class="help">{{ field.help_text|safe }}</p>
+						{% endif %}{% endcomment %}
+					</div>
+				{% endif %}
+			{% endfor %}
+	    </div>
+	  </div>
+		<div id="button-container" class="d-flex container justify-content-around">
+			<input class="btn navigation-button mt-3" type="reset" value="Réinitialiser">
+			<a href="{% url 'topicblog:list_press' %}" class="btn navigation-button mt-3">Retour à la liste</a>
+			<input class="btn navigation-button mt-3" type="submit" value="Sauvegarder" name="sauvegarder">
+		</div>
+	</div>
+    </form>
+</div>
+{% endblock %}

--- a/transport_nantes/topicblog/test_topic_blog_part_2.py
+++ b/transport_nantes/topicblog/test_topic_blog_part_2.py
@@ -446,6 +446,8 @@ class TBETest(TestCase):
             )
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
+
+
 class TBPTest(TestCase):
     def setUp(self):
 
@@ -874,6 +876,8 @@ class TBPTest(TestCase):
             )
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
+
+
 class TBLATest(TestCase):
     def setUp(self):
 

--- a/transport_nantes/topicblog/test_topic_blog_part_2.py
+++ b/transport_nantes/topicblog/test_topic_blog_part_2.py
@@ -744,7 +744,136 @@ class TBPTest(TestCase):
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
 
+    def test_edit_press_by_pkid(self):
+        """"For this test we use a list of dictionaries, that is composed of:
+            - client = the client of user (auth user, unauth and staff user)
+            - code = the statut code that should return for this user (varie)
+            - message = the error message (varie)"""
 
+        # with good pkid but item have a slug
+        users_expected_0 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth."},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " good pkid but the item have a slug"},
+        ]
+        for user_type in users_expected_0:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press_by_pkid",
+                        kwargs={
+                            "pkid": self.press_with_slug.id,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with good pkid and item have no slug
+        users_expected_1 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth."},
+            {"client": self.staff_client, "code": 200,
+             "msg": "The page MUST return 200 if we provide the"
+             " good pkid a slug"},
+        ]
+        for user_type in users_expected_1:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press_by_pkid",
+                        kwargs={
+                            "pkid": self.press_without_slug.id,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with bad pkid
+        users_expected_2 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " wrong pkid."},
+        ]
+        for user_type in users_expected_2:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press_by_pkid",
+                        kwargs={
+                            "pkid": 999999999,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+
+    def test_edit_press(self):
+        """"For this test we use a list of dictionaries, that is composed of:
+            - client = the client of user (auth user, unauth and staff user)
+            - code = the statut code that should return for this user (varie)
+            - message = the error message (varie)"""
+
+        # with good pkid and good slug
+        users_expected_0 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 200,
+             "msg": "The page MUST return 200 if we provide the"
+             " good pkid and the good slug"},
+        ]
+        for user_type in users_expected_0:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press",
+                        kwargs={
+                            "pkid": self.press_with_slug.id,
+                            "the_slug": self.press_with_slug.slug,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with good pkid bad slug
+        users_expected_1 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " good pkid and and the wrong slug"},
+        ]
+        for user_type in users_expected_1:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press",
+                        kwargs={
+                            "pkid": self.press_with_slug.id,
+                            "the_slug": "bad-slug",
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with bad pkid and bad slug
+        users_expected_2 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page should return 404 if we don't provide"
+             " good pkid and slug."},
+        ]
+        for user_type in users_expected_2:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_press",
+                        kwargs={
+                            "pkid": 999999999,
+                            "the_slug": "bad-slug",
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
 class TBLATest(TestCase):
     def setUp(self):
 

--- a/transport_nantes/topicblog/test_topic_blog_part_2.py
+++ b/transport_nantes/topicblog/test_topic_blog_part_2.py
@@ -316,7 +316,136 @@ class TBETest(TestCase):
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
 
+    def test_edit_email_by_pkid(self):
+        """"For this test we use a list of dictionaries, that is composed of:
+            - client = the client of user (auth user, unauth and staff user)
+            - code = the statut code that should return for this user (varie)
+            - message = the error message (varie)"""
 
+        # with good pkid but item have a slug
+        users_expected_0 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth."},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " good pkid but the item have a slug"},
+        ]
+        for user_type in users_expected_0:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email_by_pkid",
+                        kwargs={
+                            "pkid": self.email_with_slug.id,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with good pkid and item have no slug
+        users_expected_1 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth."},
+            {"client": self.staff_client, "code": 200,
+             "msg": "The page MUST return 200 if we provide the"
+             " good pkid a slug"},
+        ]
+        for user_type in users_expected_1:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email_by_pkid",
+                        kwargs={
+                            "pkid": self.email_without_slug.id,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with bad pkid
+        users_expected_2 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " wrong pkid."},
+        ]
+        for user_type in users_expected_2:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email_by_pkid",
+                        kwargs={
+                            "pkid": 999999999,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+
+    def test_edit_email(self):
+        """"For this test we use a list of dictionaries, that is composed of:
+            - client = the client of user (auth user, unauth and staff user)
+            - code = the statut code that should return for this user (varie)
+            - message = the error message (varie)"""
+
+        # with good pkid and good slug
+        users_expected_0 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 200,
+             "msg": "The page MUST return 200 if we provide the"
+             " good pkid and the good slug"},
+        ]
+        for user_type in users_expected_0:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email",
+                        kwargs={
+                            "pkid": self.email_with_slug.id,
+                            "the_slug": self.email_with_slug.slug,
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with good pkid bad slug
+        users_expected_1 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page MUST return 404 if we provide the"
+             " good pkid and and the wrong slug"},
+        ]
+        for user_type in users_expected_1:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email",
+                        kwargs={
+                            "pkid": self.email_with_slug.id,
+                            "the_slug": "bad-slug",
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
+        # with bad pkid and bad slug
+        users_expected_2 = [
+            {"client": self.user_client, "code": 403,
+             "msg": "Normal users can't access this page."},
+            {"client": self.client, "code": 302,
+             "msg": "The page should return 302 if not auth"},
+            {"client": self.staff_client, "code": 404,
+             "msg": "The page should return 404 if we don't provide"
+             " good pkid and slug."},
+        ]
+        for user_type in users_expected_2:
+            response = user_type["client"].get(
+                reverse("topicblog:edit_email",
+                        kwargs={
+                            "pkid": 999999999,
+                            "the_slug": "bad-slug",
+                        })
+            )
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])
 class TBPTest(TestCase):
     def setUp(self):
 
@@ -610,201 +739,6 @@ class TBPTest(TestCase):
                 reverse("topicblog:list_press_by_slug",
                         kwargs={
                             "the_slug": self.press_with_slug.slug,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-
-    def test_view_email_by_pkid_only(self):
-        """"For this test we use a list of dictionaries, that is composed of:
-            - client = the client of user (auth user, unauth and staff user)
-            - code = the statut code that should return for this user (varie)
-            - message = the error message (varie)"""
-
-        # with good pkid but item have a slug
-        users_expected_0 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page MUST return 404 if we provide the"
-             " good pkid but the item have a slug"},
-        ]
-        for user_type in users_expected_0:
-            response = user_type["client"].get(
-                reverse("topicblog:view_email_by_pkid_only",
-                        kwargs={
-                            "pkid": self.email_with_slug.id,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with good pkid but item have no slug
-        users_expected_1 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 200,
-             "msg": "The page MUST return 200 if we provide the"
-             " good pkid and the item have no slug"},
-        ]
-        for user_type in users_expected_1:
-            response = user_type["client"].get(
-                reverse("topicblog:view_email_by_pkid_only",
-                        kwargs={
-                            "pkid": self.email_without_slug.id,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with bad pkid
-        users_expected_2 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page should return 404 if we don't provide"
-             " a good pkid"},
-        ]
-        for user_type in users_expected_2:
-            response = user_type["client"].get(
-                reverse("topicblog:view_email_by_pkid_only",
-                        kwargs={
-                            "pkid": 999999999,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-
-    def test_edit_email_by_pkid(self):
-        """"For this test we use a list of dictionaries, that is composed of:
-            - client = the client of user (auth user, unauth and staff user)
-            - code = the statut code that should return for this user (varie)
-            - message = the error message (varie)"""
-
-        # with good pkid but item have a slug
-        users_expected_0 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth."},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page MUST return 404 if we provide the"
-             " good pkid but the item have a slug"},
-        ]
-        for user_type in users_expected_0:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email_by_pkid",
-                        kwargs={
-                            "pkid": self.email_with_slug.id,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with good pkid and item have no slug
-        users_expected_1 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth."},
-            {"client": self.staff_client, "code": 200,
-             "msg": "The page MUST return 200 if we provide the"
-             " good pkid a slug"},
-        ]
-        for user_type in users_expected_1:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email_by_pkid",
-                        kwargs={
-                            "pkid": self.email_without_slug.id,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with bad pkid
-        users_expected_2 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page MUST return 404 if we provide the"
-             " wrong pkid."},
-        ]
-        for user_type in users_expected_2:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email_by_pkid",
-                        kwargs={
-                            "pkid": 999999999,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-
-    def test_edit_email(self):
-        """"For this test we use a list of dictionaries, that is composed of:
-            - client = the client of user (auth user, unauth and staff user)
-            - code = the statut code that should return for this user (varie)
-            - message = the error message (varie)"""
-
-        # with good pkid and good slug
-        users_expected_0 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 200,
-             "msg": "The page MUST return 200 if we provide the"
-             " good pkid and the good slug"},
-        ]
-        for user_type in users_expected_0:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email",
-                        kwargs={
-                            "pkid": self.email_with_slug.id,
-                            "the_slug": self.email_with_slug.slug,
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with good pkid bad slug
-        users_expected_1 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page MUST return 404 if we provide the"
-             " good pkid and and the wrong slug"},
-        ]
-        for user_type in users_expected_1:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email",
-                        kwargs={
-                            "pkid": self.email_with_slug.id,
-                            "the_slug": "bad-slug",
-                        })
-            )
-            self.assertEqual(response.status_code,
-                             user_type["code"], msg=user_type["msg"])
-        # with bad pkid and bad slug
-        users_expected_2 = [
-            {"client": self.user_client, "code": 403,
-             "msg": "Normal users can't access this page."},
-            {"client": self.client, "code": 302,
-             "msg": "The page should return 302 if not auth"},
-            {"client": self.staff_client, "code": 404,
-             "msg": "The page should return 404 if we don't provide"
-             " good pkid and slug."},
-        ]
-        for user_type in users_expected_2:
-            response = user_type["client"].get(
-                reverse("topicblog:edit_email",
-                        kwargs={
-                            "pkid": 999999999,
-                            "the_slug": "bad-slug",
                         })
             )
             self.assertEqual(response.status_code,

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -570,7 +570,7 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
             # the only one with a publication date. For now it picks the
             # most recent.
             publication_date__isnull=False
-            )
+        )
         if len(tbe_object) > 1:
             raise ValueError(
                 "There is more than one TBEmail with slug {} and a not-null "
@@ -707,6 +707,7 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
 
 ######################################################################
 # TopicBlogPress
+
 
 class TopicBlogPressViewOnePermissions(PermissionRequiredMixin):
     """Custom Permission class to require different permissions


### PR DESCRIPTION
For the template config tags i use:
```
  template_config_default = {
        "optional_fields_for_publication": (
                'header_image', 'header_description',
                'body_image', 'body_image_alt_text',
                'twitter_title', 'twitter_description',
                'twitter_image', 'og_title',
                'og_description', 'og_image'
        ),
        "one_of_fields_for_publication": [
                ['header_title', 'header_description'],
            ],
        # Dependent fields: if one in a group is provided, the others must
        # be as well before we can publish.
        "dependent_field_names": [
                ['body_image_1', 'body_image_1_alt_text'],
            ],
    }
    template_config = {
        'topicblog/content_press.html': {
            'user_template_name': 'Classic',
            'active': True,
            "fields": {
                'slug': True,
                'title': True,
                'subject': True,
                'body_text_1_md': True,
```
The template use (cta_1_slug ,cta_1_label, cta_2_slug and cta_2_label ) but  the TopicBlogPres object don't have cta. What should I do ?
