### PR TITLE
Add unsub link 406

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -52,7 +52,7 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
         <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
             <p style="margin:0;font-size:14px;line-height:20px;">
                 &reg; Mobilitains 2022<br>
-                <a class="unsub" href="{{ unsub_link }}" style="color:#cccccc;text-decoration:underline;">Se désabonner</a>
+                <a class="unsub" href="{{ request.scheme }}://{{ unsub_link }}" style="color:#cccccc;text-decoration:underline;">Se désabonner</a>
             </p>
         </td>
     </tr> <!-- End of Footer -->

--- a/transport_nantes/topicblog/templates/topicblog/unsubscribe_from_mailing_list.html
+++ b/transport_nantes/topicblog/templates/topicblog/unsubscribe_from_mailing_list.html
@@ -1,0 +1,25 @@
+{% extends 'topicblog/base_email.html' %}
+
+{% block app_content %}
+
+{% if not confirmed_unsub %}
+{# GET #}
+    <form method="post" action="{% url "topicblog:email-unsub" token %}"
+    class="d-flex flex-column flex-wrap col-10 col-md-6 mx-auto">
+        {% csrf_token %}
+        <h1 class="d-flex text-center">
+            Voulez vous vraiment vous désabonner de la liste de diffusion "{{send_record_mailing_list}}" ?
+        </h1>
+        <div class="d-flex flex-row flex-wrap col-6 mx-auto mt-3 justify-content-around">
+            <button class="btn navigation-button" type="submit">Oui</button>
+            <a class="btn navigation-button" href="{% url "index" %}">Non</a>
+        </div>
+    </form>
+{% else %}
+{# POST #}
+    <h1 class="d-flex col-10 col-md-6 mx-auto text-center">
+        Vous vous êtes désabonné(e) de la liste de diffusion "{{send_record_mailing_list}}"
+    </h1>
+{% endif %}
+
+{% endblock app_content %}

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -937,7 +937,7 @@ class TopicBlogEmailTest(TestCase):
         self.admin_client.force_login(self.superuser)
         self.no_permissions_client.force_login(self.no_permissions_user)
 
-        # Anonymous users are invited tol og in and from there, you
+        # Anonymous users are invited to log in and from there, you
         # land either on 403 Forbidden or 200 OK depending on the
         # user's permissions.
         self.perm_needed_responses = [
@@ -1010,3 +1010,12 @@ class TopicBlogEmailTest(TestCase):
 
     #     # Check that the send record is created
     #     self.assertEqual(1, TopicBlogEmailSendRecord.objects.count())
+
+    def test_send_email_status_code(self):
+        url = reverse('topicblog:send_email',
+                      args=[self.email_article.slug])
+
+        for user_type in self.perm_needed_responses:
+            response = user_type["client"].get(url)
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -1019,3 +1019,11 @@ class TopicBlogEmailTest(TestCase):
             response = user_type["client"].get(url)
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
+
+    def test_unsubscribe_invalid_token_status_code(self):
+        url = reverse('topicblog:email-unsub',
+                      args=["invalid_token"])
+
+        for user_type in self.no_perm_needed_responses:
+            response = user_type["client"].get(url)
+            self.assertEqual(response.status_code, 404)

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -19,6 +19,9 @@ urlpatterns = [
          name='view_press_by_slug'),
     path('la/<slug:the_slug>/', views.TopicBlogLauncherView.as_view(),
          name='view_launcher_by_slug'),
+    path('e/unsub/<str:token>/',
+         views.UnsubscribeFromMailingListView.as_view(),
+         name="email-unsub"),
 
     path('admin/t/view/<int:pkid>/', views.TopicBlogItemViewOne.as_view(),
          name='view_item_by_pkid_only'),

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -22,7 +22,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.urls import reverse, reverse_lazy
 from django.utils.html import strip_tags
 
-from asso_tn.utils import StaffRequired, token_valid
+from asso_tn.utils import StaffRequired, make_timed_token, token_valid
 from mailing_list.events import (get_subcribed_users_email_list,
                                  unsubscribe_user_from_list)
 from mailing_list.models import MailingList
@@ -613,7 +613,7 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
                 the_slug=tbe_slug,
                 recipient=[recipient],
                 mailing_list=mailing_list,
-                send_record=send_record.id)
+                send_record_id=send_record.id)
 
             logger.info(f"Successfully prepared email to {recipient}")
             custom_email.send(fail_silently=False)
@@ -622,11 +622,13 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
         return super().form_valid(form)
 
     def prepare_email(self, pkid: int, the_slug: str, recipient: list,
-                      mailing_list: MailingList, send_record: int) \
+                      mailing_list: MailingList, send_record_id: int) \
             -> mail.EmailMultiAlternatives:
         """
         Creates a sendable email object from a TBEmail with a mail
         client-friendly template, given a pkid, a slug and a mail adress.
+
+        send_record is the pk_id of the TopicBlogEmailSendRecord
         """
         if pkid < 0 or the_slug is None:
             logger.info(f"pkid < 0 ({pkid}) or slug is none ({the_slug})")
@@ -635,17 +637,8 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
         # Preparing the email
         tb_email = TopicBlogEmail.objects.get(pk=pkid, slug=the_slug)
         self.template_name = tb_email.template_name
-        # The context statements will be moved to a _set_context method
-        # once all the features are implemented.
-        context = dict()
-        context["context_appropriate_base_template"] = \
-            "topicblog/base_email.html"
-        context["email"] = tb_email
-        context["host"] = get_current_site(self.request).domain
 
-        # The unsubscribe link is created with the send_record and the
-        # user's email hidden in a token.
-        context["unsub_link"] = self.get_unsubscribe_link()
+        context = self._set_email_context(recipient, send_record_id, tb_email)
 
         try:
             email = self._create_email_object(tb_email, context, recipient)
@@ -689,22 +682,22 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
 
         return email
 
-    def _set_email_context(self, recipient: list, mailing_list: MailingList,
-                           slug: str) -> dict:
+    def _set_email_context(
+            self, recipient: list, send_record_id: int,
+            tb_email: TopicBlogEmail) -> dict:
         """
         Sets the context for the email to be sent.
         """
         context = dict()
         context["context_appropriate_base_template"] = \
             "topicblog/base_email.html"
+        context["email"] = tb_email
         context["host"] = get_current_site(self.request).domain
-        # TODO: create a unsub link
-        # args = (recipient, slug, mailing_list)  # TODO: Add missing args
-        # The make_timed_token function isn't ready yet (10/3/22)
-        # context["unsub_link"] = make_timed_token(*args)
 
-        # TODO: Create a template tag to have redirect links embedded in the
-        # email.
+        # The unsubscribe link is created with the send_record and the
+        # user's email hidden in a token.
+        context["unsub_link"] = \
+            self.get_unsubscribe_link(recipient[0], send_record_id)
 
         return context
 
@@ -723,11 +716,17 @@ class TopicBlogEmailSend(PermissionRequiredMixin, LoginRequiredMixin,
         send_record.save()
         return send_record
 
-    def get_unsubscribe_link(self) -> str:
+    def get_unsubscribe_link(self, email: str, send_record_id: int) -> str:
         """
         Create a link to unsubscribe the user from the mailing list.
         """
-        pass
+        email = email
+        k_minutes_in_six_months = 60*24*30*6
+        token = make_timed_token(
+            email, k_minutes_in_six_months, int_key=send_record_id)
+        url = reverse("topicblog:email-unsub", kwargs={"token": token})
+        unsub_link = f"{get_current_site(self.request).domain}{url}"
+        return unsub_link
 
 
 class UnsubscribeFromMailingListView(TemplateView):

--- a/transport_nantes/transport_nantes/urls.py
+++ b/transport_nantes/transport_nantes/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
          {'the_slug': 'index'},
          name='index'),
     path('index2', AssoView.as_view(template_name='asso_tn/index.html',),
-                              name='index'),
+         name='index2'),
     path('admin/', admin.site.urls),
     path('auth/', include('authentication.urls')),
     path('captcha/', include('captcha.urls')),


### PR DESCRIPTION
This PR is based on #561 (TBE-create-SendRecord-532)

It adds an URL that allows the user to unsub from a mailing list by parsing the token.
A confirmation is asked from the user, and they are then shown a confirmation page.

The link is embedded inside TBEmails when they are rendered to send via emails.

Closes #406

I leave it as a draft because the tests aren't written yet.