### PR TITLE
Fix failing test mailinglist

### DIFF
--- a/transport_nantes/mailing_list/tests.py
+++ b/transport_nantes/mailing_list/tests.py
@@ -120,7 +120,7 @@ class MailingListIntegrationTestCase(LiveServerTestCase):
     #     self.assertIsNotNone(
     #         user,
     #         msg="The user was not created during mailing list signup")
-    #     mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+    #     mailing_list_event = MailingListEvent.objects.filter(user=user).first()
     #     self.assertIsNotNone(mailing_list_event,
     #                          msg="The mailing event is not created"
     #                              "on quick sign up")
@@ -144,11 +144,11 @@ class MailingListIntegrationTestCase(LiveServerTestCase):
         captcha_input.send_keys("PASSED")
         self.selenium.find_element_by_css_selector(
             "form button[type=submit]").click()
-        user = User.objects.filter(email="admin@mail.com")[0]
+        user = User.objects.filter(email="admin@mail.com").first()
         self.assertIsNotNone(
             user,
             msg="The user created during setUp does not exist")
-        mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+        mailing_list_event = MailingListEvent.objects.filter(user=user).first()
         self.assertIsNotNone(mailing_list_event,
                              msg="The mailing event was not created "
                                  "on quick sign up")
@@ -179,7 +179,7 @@ class MailingListIntegrationTestCase(LiveServerTestCase):
     #     user = User.objects.filter(email="nomail@nomail.fr").first()
     #     self.assertIsNotNone(user,
     #                          msg="The user is not created on quick sign up")
-    #     mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+    #     mailing_list_event = MailingListEvent.objects.filter(user=user).first()
     #     self.assertIsNotNone(mailing_list_event,
     #                          msg="The mailing event is not created"
     #                              "on quick sign up")
@@ -210,7 +210,7 @@ class MailingListIntegrationTestCase(LiveServerTestCase):
     #     user = User.objects.filter(email="nomail@nomail.fr").first()
     #     self.assertIsNotNone(user,
     #                          msg="The user is not created on quick sign up")
-    #     mailing_list_event = MailingListEvent.objects.filter(user=user)[0]
+    #     mailing_list_event = MailingListEvent.objects.filter(user=user).first()
     #     self.assertIsNotNone(mailing_list_event,
     #                          msg="The mailing event is not created"
     #                              "on quick sign up")


### PR DESCRIPTION
The test initially made a few mistakes :
The quick form doesn't have a mail field when the user is connected,
and the title of the test "testing_quick_form_logged_in" implies that
the user is logged in. Instead of that simply a "s'inscrire" button
is displayed.
There isn't a captcha to fill either, as we don't ask for one for logged
in users.
The test was checking for existence of a user that never was created
"admin@mail.com"

This commit fixes the above :
- logs in a user (by adding a session cookie to the browser)
- clicks on the button without trying to fill an absent email field
- Checks for presence and correct value of the subsequently created
MailingListEvent