### PR TITLE
Add warning before send

### DIFF
--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -626,7 +626,7 @@ class TopicBlogEmail(TopicBlogObjectSocialBase):
         ],
     }
     template_config = {
-        'topicblog/content_email.html': {
+        'topicblog/content_email_client.html': {
             'user_template_name': 'Classic',
             'active': True,
             "fields": {
@@ -690,6 +690,18 @@ class TopicBlogEmail(TopicBlogObjectSocialBase):
             return reverse("topicblog:edit_email",
                            kwargs={"pkid": self.pk,
                                    "the_slug": self.slug})
+
+    def get_participating_field_names(self) -> set:
+        return TopicBlogItem.get_participating_field_names(self)
+
+    def get_missing_publication_field_names(self) -> set:
+        return TopicBlogItem.get_missing_publication_field_names(self)
+
+    def is_publishable(self) -> bool:
+        return TopicBlogItem.is_publishable(self)
+
+    def publish(self):
+        return TopicBlogItem.publish(self)
 
 
 class TopicBlogEmailSendRecord(models.Model):

--- a/transport_nantes/topicblog/static/topicblog/email-sending-confirm.js
+++ b/transport_nantes/topicblog/static/topicblog/email-sending-confirm.js
@@ -3,6 +3,9 @@ This script is used to display the number of recipients before
 sending a TBEmail object to a mailing list, and ask for confirmation
 */
 
+// Initial state
+document.getElementById('nb-recipients').innerHTML = "0";
+document.getElementById("send-email-btn").disabled = true;
 
 async function get_number_of_recipients(mailing_list_token) {
     let response = await $.ajax({
@@ -12,15 +15,40 @@ async function get_number_of_recipients(mailing_list_token) {
     return response;
 }
 
+//// This Event listener updates the number of recipients message upon selection
+//// of a mailing list
+// This fires when we select a mailing list in the dropdown menu
+document.getElementById('id_mailing_list').addEventListener('change', function() {
+    let mailing_list_token = this.value;
+    console.log(mailing_list_token);
+    if (!mailing_list_token) {
+        document.getElementById('nb-recipients').innerHTML = "0";
+        document.getElementById("send-email-btn").disabled = true;
+    }
+    // Sends the mailing_list_token to the server to get the number of recipients
+    get_number_of_recipients(mailing_list_token).then(function(response) {
+        // The response is a dict with a key "count" and a value of the number of recipients
+        let number_of_recipients = response.count;
+        // The number_of_recipients is identified and isolated in the id "nb-recipients"
+        // We replace its value with the one received from the server.
+        document.getElementById("nb-recipients").innerHTML = number_of_recipients;
+        number_of_recipients = parseInt(number_of_recipients);
+        // If the number of recipients is 0, we disable the send-email-btn
+        if (number_of_recipients == 0) {
+            document.getElementById("send-email-btn").disabled = true;
+        }
+        else {
+            document.getElementById("send-email-btn").disabled = false;
+        }
+    });
+});
+
 // This fires only when the "Envoyer" button is clicked
 document.getElementById('send-email-btn').addEventListener('click', async function (event) {
     // Prevent the button to POST
     event.preventDefault();
-    // Get the selected value in the dropdown
-    let mailing_list_token = document.getElementById('id_mailing_list').value;
-    // Result of the Ajax request is a dict {"count" : <int:number_of_recipients>}
-    let number_of_recipients = await get_number_of_recipients(mailing_list_token);
-    number_of_recipients = number_of_recipients["count"];
+
+    number_of_recipients = parseInt(document.getElementById("nb-recipients").innerHTML);
     if (number_of_recipients > 0) {
         // Display a confirmation alert with OK and cancel,if OK is clicked, it evaluates to True.
         if (confirm("Vous êtes sur le point d'envoyer un email à " + number_of_recipients + " destinataires.\n\n" +
@@ -30,7 +58,5 @@ document.getElementById('send-email-btn').addEventListener('click', async functi
             document.getElementById('send-email-btn').innerHTML = 'Envoi en cours...';
             document.getElementById('send-email-form').submit();
         };
-    } else {
-        alert("Aucun destinataire n'a été trouvé.\n\n");
     }
 })

--- a/transport_nantes/topicblog/static/topicblog/email-sending-confirm.js
+++ b/transport_nantes/topicblog/static/topicblog/email-sending-confirm.js
@@ -1,0 +1,36 @@
+/*
+This script is used to display the number of recipients before
+sending a TBEmail object to a mailing list, and ask for confirmation
+*/
+
+
+async function get_number_of_recipients(mailing_list_token) {
+    let response = await $.ajax({
+        url: '/tb/ajax/get-number-of-recipients/' + mailing_list_token + '/',
+        method: 'GET',
+    })
+    return response;
+}
+
+// This fires only when the "Envoyer" button is clicked
+document.getElementById('send-email-btn').addEventListener('click', async function (event) {
+    // Prevent the button to POST
+    event.preventDefault();
+    // Get the selected value in the dropdown
+    let mailing_list_token = document.getElementById('id_mailing_list').value;
+    // Result of the Ajax request is a dict {"count" : <int:number_of_recipients>}
+    let number_of_recipients = await get_number_of_recipients(mailing_list_token);
+    number_of_recipients = number_of_recipients["count"];
+    if (number_of_recipients > 0) {
+        // Display a confirmation alert with OK and cancel,if OK is clicked, it evaluates to True.
+        if (confirm("Vous êtes sur le point d'envoyer un email à " + number_of_recipients + " destinataires.\n\n" +
+            "Êtes-vous sûr de vouloir continuer ?") == true) {
+            // If OK is clicked, we submit the form with a visual feedback
+            document.getElementById('send-email-btn').disabled = true;
+            document.getElementById('send-email-btn').innerHTML = 'Envoi en cours...';
+            document.getElementById('send-email-form').submit();
+        };
+    } else {
+        alert("Aucun destinataire n'a été trouvé.\n\n");
+    }
+})

--- a/transport_nantes/topicblog/templates/topicblog/base_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_email.html
@@ -37,20 +37,18 @@ Maybe there's a better way, I just haven't found it yet.
 				</form>
 			{% endif %}
 	    {% endif %}
-
+		<p class="mx-1">
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{{ page.get_edit_url }}">Modifier</a>
 
 	    {% if page.publication_date %}
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{% url 'topic_blog:view_email_by_slug' page.slug|default:'--sans-slug--' %}">Visualiser (usager)</a>
-	    {% if page.servable %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Retirer</a>
-	    {% else %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Republier</a>
-	    {% endif %}{% endif %}
+		{% else %}
+		<a type="button" class="btn btn-outline-info btn-sm"
+	       href="{% url 'topic_blog:view_email_by_slug' page.slug|default:'--sans-slug--' %}">Voir la version publiée</a>
+	    {% endif %}
+		</p>
 	</p>
     </div>
 </div>

--- a/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
@@ -9,10 +9,11 @@
 
 {% block content %}
 
-    <form id="send-email-form" class="col-10 mx-auto"
+    <form id="send-email-form" class="col-10 mx-auto mt-2"
     action="{% url 'topicblog:send_email' tbe_slug %}"
     method="POST">{% csrf_token %}
         {{form|crispy}}
+        <p class="text-muted small">Nombre de destinataires : <span id="nb-recipients">0</span></p>
         <button id="send-email-btn" type="submit" class="btn navigation-button">Envoyer</button>
     </form>
 

--- a/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogemail_send_form.html
@@ -1,13 +1,19 @@
 {% extends 'topicblog/content.html' %}
 {% load crispy_forms_tags %}
+{% load static %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script src="{% static 'topicblog/email-sending-confirm.js' %}"></script>
+{% endblock scripts %}
 
 {% block content %}
 
-    <form class="col-10 mx-auto"
+    <form id="send-email-form" class="col-10 mx-auto"
     action="{% url 'topicblog:send_email' tbe_slug %}"
     method="POST">{% csrf_token %}
         {{form|crispy}}
-        <button type="submit" class="btn navigation-button">Envoyer</button>
+        <button id="send-email-btn" type="submit" class="btn navigation-button">Envoyer</button>
     </form>
 
 {% endblock content %}

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -82,7 +82,8 @@ urlpatterns = [
          name='edit_email_by_slug'),
     path('admin/p/edit/<slug:the_slug>/', views.TopicBlogPressEdit.as_view(),
          name='edit_press_by_slug'),
-    path('admin/la/edit/<slug:the_slug>/', views.TopicBlogLauncherEdit.as_view(),
+    path('admin/la/edit/<slug:the_slug>/',
+         views.TopicBlogLauncherEdit.as_view(),
          name='edit_launcher_by_slug'),
 
     path('admin/t/list/', views.TopicBlogItemList.as_view(),
@@ -100,7 +101,8 @@ urlpatterns = [
          name='list_emails_by_slug'),
     path('admin/p/list/<slug:the_slug>/', views.TopicBlogPressList.as_view(),
          name='list_press_by_slug'),
-    path('admin/la/list/<slug:the_slug>/', views.TopicBlogLauncherList.as_view(),
+    path('admin/la/list/<slug:the_slug>/',
+         views.TopicBlogLauncherList.as_view(),
          name='list_launcher_by_slug'),
 
     path('admin/e/send/<slug:the_slug>/', views.TopicBlogEmailSend.as_view(),
@@ -112,6 +114,9 @@ urlpatterns = [
          name="get_slug_dict"),
     path('ajax/get-url-list/', views.get_url_list,
          name="get_url_list"),
+    path('ajax/get-number-of-recipients/<str:mailing_list_token>/',
+         views.get_number_of_recipients,
+         name="get_number_of_recipients"),
 ]
 
 # Need topic creation.


### PR DESCRIPTION
based on #563 

Add a confirmation window before sending a TBEmail to a mailing list.

It informs you about how many people are subscribed to a mailing list, and makes an extra step to prevent accidental sending.