### PR TITLE
Slight improvement homepage

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -435,7 +435,10 @@ span.centered {
     margin: 2px;
     padding: 4px;
 }
-
+.teaser-text {
+    -webkit-mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+}
 .higlighted-blue {
     font-weight: bold;
     background-color: var(--mobilitains-bleu);

--- a/transport_nantes/asso_tn/templates/asso_tn/index.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/index.html
@@ -5,7 +5,7 @@
 {% load launcher %}
 {% load item_teaser %}
 {% block content %}
-{% item_teaser 'ligne-johanna-rolland-pour-plus-de-mobilite' %}
+{% item_teaser 'ligne-johanna-rolland-pour-plus-de-mobilite' 100 %}
 <div class="background-ad-hoc-blue">
     <div class="d-flex flex-column p-4 p-xl-5">
         <h2>Les projets Mobilitains</h2>

--- a/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
+++ b/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
@@ -6,8 +6,8 @@
            <p class="card-text text-white">{{ item.header_description }}</p>
          </div>
     </div>
-    <div class="p-4">
-         <p>{{ item.body_text_1_md|truncatewords:50 }}</p>
+    <div class="p-4 d-flex flex-column">
+         <p class='teaser-text'>{{ item.body_text_1_md|truncatewords:50 }}</p>
 		{% comment %}
 	    If the launcher slug does not reference a launcher in the
 	    database, the templatetag will pass None to this template
@@ -20,6 +20,6 @@
 	    reverse url lookup would see an empty argument, conclude
 	    no argument, and so 500.
 	        {% endcomment %} {% if item.slug %}
-               <a href="{% url 'topic_blog:view_item_by_slug' item.slug %}" class="btn donation-button btn-lg" >en lire plus <i class="fa fa-arrow-right"></i></a>{% else %}404{%endif %}
+               <a href="{% url 'topic_blog:view_item_by_slug' item.slug %}" class="btn donation-button btn-lg mx-auto" >En lire plus <i class="fa fa-arrow-right"></i></a>{% else %}404{% endif %}
     </div>
 </div>

--- a/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
+++ b/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
@@ -7,7 +7,7 @@
          </div>
     </div>
     <div class="p-4 d-flex flex-column">
-         <p class='teaser-text'>{{ item.body_text_1_md|truncatewords:50 }}</p>
+         <p class='teaser-text'>{{ item.body_text_1_md|truncatewords:truncate_after }}</p>
 		{% comment %}
 	    If the launcher slug does not reference a launcher in the
 	    database, the templatetag will pass None to this template

--- a/transport_nantes/topicblog/templatetags/item_teaser.py
+++ b/transport_nantes/topicblog/templatetags/item_teaser.py
@@ -6,10 +6,11 @@ register = template.Library()
 
 logger = logging.getLogger("django")
 
+
 @register.inclusion_tag('topicblog/template_tags/item_teaser.html')
-def item_teaser(slug):
+def item_teaser(slug, truncate_after=50):
     item = TopicBlogItem.objects.filter(
         slug__iexact=slug, publication_date__isnull=False).first()
     if item is None:
         logger.error(f"item_teaser failed to find slug: \"{slug}\".")
-    return {'item': item}
+    return {'item': item, 'truncate_after': truncate_after}

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -3,8 +3,9 @@ from django.template import Template, Context
 from django.test import TestCase
 from django.urls import reverse_lazy
 from django.contrib.auth.models import User
-from topicblog.models import TopicBlogItem,TopicBlogLauncher
+from topicblog.models import TopicBlogItem, TopicBlogLauncher
 from datetime import datetime, timezone
+
 
 class TBEmailTemplateTagsTests(TestCase):
 
@@ -159,13 +160,13 @@ class TBItemTeaserTemplateTagsTests(TestCase):
     def test_item_teaser(self):
         url = reverse_lazy("topic_blog:view_item_by_slug",
                            args=[self.item.slug])
-        link = f'<a href="{url}" class="btn donation-button btn-lg" >'
+        link = f'<a href="{url}"'
         title = \
             f'<h2 class="card-title text-white">{self.item.header_title}</h2>'
         item_description = self.item.header_description
         descrition = \
             f'<p class="card-text text-white">{item_description}</p>'
-        text = f'<p>{ self.item.body_text_1_md}</p>'
+        text = f"<p class='teaser-text'>{ self.item.body_text_1_md}</p>"
         template_string = (
             "{% load item_teaser %}"
             "{% item_teaser slug %}")


### PR DESCRIPTION
Edit : Failing test is the test_item_teaser that has hardcoded html, going to update this) 
Edit 2 : Solved !

This PR includes 2 improvements, one about the visual aspect of the new index, the other about flexibility of the teasing feature.

The visual improvement has been inspired by the news website I browse, and social medias : You are usually shown just enough to make you want to click, while the text fades out. 

Examples:
![image](https://user-images.githubusercontent.com/70256364/160563991-ab812082-0c3c-45ce-9685-19e32f8cc6a2.png)
![image](https://user-images.githubusercontent.com/70256364/160564110-771b7a43-6117-4775-9a00-f7e4b8a89b52.png)
![image](https://user-images.githubusercontent.com/70256364/160564207-4c67b78f-8c70-4b3c-933f-16e991799ab8.png)

So my proposition for this :

![image](https://user-images.githubusercontent.com/70256364/160565087-5f02cf60-65a1-4007-a70c-a4a300e04882.png)
![image](https://user-images.githubusercontent.com/70256364/160565191-560287f8-ae8f-4708-8c27-3e7d73614ed7.png)


The next improvement is about how much you reveal before fading out. 
For this I leave you to the commit message : 
>It's a proposition to make the number of words displayed adjustable
depending on what we want to display.
I think it could be used to show just enough to tease curisity from the
user, but that line depends on the item we apply the teasing to.
>
>For now it's hardcoded, but so is the item so it's still a git action to
edit this value.
However, I think we could add an optional field "teasing_length" to the
TBItem model to make it configurable in the future.

In code it translate to simply change this variable : 
![image](https://user-images.githubusercontent.com/70256364/160566383-385fae74-87a9-4dc6-ad98-d576550a528a.png)

This is part of #559 