### PR TITLE
Fix image banners overlapping the Navbar

### DIFF
--- a/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
@@ -180,26 +180,9 @@
 					</div>
 				</nav>
 
-				<div>
-					{% comment %}
-					<ul>
-								<li class="nav-item dropdown">
-								<a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-user" aria-hidden="true"></i></a>
-								<div class="dropdown-menu">
-								{% if user.is_authenticated %}
-								<a class="dropdown-item" href="{% url 'authentication:mod' %}"><i class="fa fa-user" style="color:gray" aria-hidden="true"></i> Profile</a>
-								<form method="POST" action="{% url 'authentication:logout' %}">{% csrf_token %}<button type="submit" class="btn btn-link"><i class="fa fa-sign-out" style="color:gray" aria-hidden="true"></i> Déconnexion</button></form>
-								{% else %}{% if not is_production %}
-								<a class="dropdown-item" href="{% url 'authentication:login' %}"><i class="fa fa-sign-in" style="color:gray" aria-hidden="true"></i> Connexion</a>{% endif %}
-								{% endif %}
-								</div>
-								</li>
-					</ul>
-					{% endcomment %}
-				</div>
 				{% if banner_is_present %}
 				<div class="page-holder bg-cover">
-					<div class="container pt-5 pb-4 px-5 mt-n5 d-flex flex-column">
+					<div class="container pt-5 pb-4 px-5 d-flex flex-column">
 						<p class="cf_text">{{ banner_text }}</p>
 						<a href="{{banner_button_link}}"
 							class="d-flex btn donation-button mx-auto">
@@ -210,7 +193,7 @@
 				{% endif %}
 			{% endblock navbar %}
 			{% block content %}
-				<div class="hero-image mt-n3">
+				<div class="hero-image">
 					<div class="hero-text">
 						<h1 style="color: white;" class="hero-title">{{ page.hero_title }}</h1>
 						<p style="color: white;" class="hero-description">{{ page.hero_description }}</p>

--- a/transport_nantes/asso_tn/templates/asso_tn/crowdfunding.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/crowdfunding.html
@@ -33,7 +33,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ hero_title }}</h1>
           <p class="hero-description">{{ hero_description }}</p>

--- a/transport_nantes/stripe_app/tests.py
+++ b/transport_nantes/stripe_app/tests.py
@@ -220,35 +220,35 @@ class TestStripeAppSelenium(LiveServerTestCase):
         self.browser.find_element_by_id('id_postal_code').send_keys('12345')
         self.browser.find_element_by_id('id_city').send_keys('City')
         # Check the consent box
-        self.browser.find_element_by_xpath(
-            '/html/body/div[4]/form/div[8]/div/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='id_data_collect']").click()
 
     def fill_amount_form_sub_20euros(self):
         """Fill the amount form with a monthly sub of 20 euros"""
         # Select "Je donne tous les mois"
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[1]/div/div[2]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='id_donation_type_1']").click()
         # Select '20€'
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[2]/div/div[3]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='subscription_amount_rb_2']").click()
 
     def fill_amount_form_onetime_preset_amount(self):
         """Fill the amount form with a one time payment"""
         # Select "Je donne une fois"
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[1]/div/div[1]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='id_donation_type_0']").click()
         # Select the 2nd choice (preset amount)
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[3]/div/div[2]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='payment_amount_rb_1']").click()
 
     def fill_amount_form_onetime_free_amount(self):
         """Fill the amount form with a one time payment"""
         # Select "Je donne une fois"
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[1]/div/div[1]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='id_donation_type_0']").click()
         # Select the 4th choice (free amount)
-        self.browser.find_element_by_xpath(
-            '/html/body/div[3]/form/div[3]/div/div[4]/label').click()
+        self.browser.find_element_by_css_selector(
+            "label[for='payment_amount_rb_1']").click()
         # Fill the free amount
         self.browser.find_element_by_id('free_amount').send_keys('15')
 

--- a/transport_nantes/topicblog/templates/topicblog/communique_presse_1.html
+++ b/transport_nantes/topicblog/templates/topicblog/communique_presse_1.html
@@ -54,7 +54,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ page.header_title }}</h1>
           <p class="hero-description">{{ page.header_description }}</p>

--- a/transport_nantes/topicblog/templates/topicblog/content.html
+++ b/transport_nantes/topicblog/templates/topicblog/content.html
@@ -61,7 +61,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ page.header_title }}</h1>
           <p class="hero-description">{{ page.header_description }}</p>

--- a/transport_nantes/topicblog/templates/topicblog/content_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email.html
@@ -39,7 +39,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ page.header_title }}</h1>
           <p class="hero-description">{{ page.header_description }}</p>

--- a/transport_nantes/topicblog/templates/topicblog/content_launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_launcher.html
@@ -39,7 +39,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ page.header_title }}</h1>
           <p class="hero-description">{{ page.header_description }}</p>

--- a/transport_nantes/topicblog/templates/topicblog/content_press.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press.html
@@ -39,7 +39,7 @@
 
 {% block content %}
 <!-- Banner with the image above the written content -->
-<div class="hero-image mt-n3">
+<div class="hero-image">
      <div class="hero-text">
           <h1 class="hero-title">{{ page.header_title }}</h1>
           <p class="hero-description">{{ page.header_description }}</p>


### PR DESCRIPTION
In commit 70d41a8262a67edb5437e49e9098d1e67f84e614, the ul tag was
removed from a div separating the navbar from the content.
The UL tag inside it forced a small gap that was then covered by a
negative top margin ("mt-n3"). The removal of this tag made the negative
margin overlap the navbar, because it didn't have the ul space to cover.

Instead of messing with the CSS, I removed the useless ul tag alongside
its parent div (that was also useless because it had no properties).
Removing this div also removes the need to have a negative margin that
covers the gap left by the ul tag.

This negative margin was present in base_mobilitain.html but also in
most base templates, because they came from base_mobilitain.html.

Closes #599