### PR TITLE
Delete references to publication in TopicBlogLauncher base template

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/base_launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_launcher.html
@@ -20,37 +20,9 @@ Maybe there's a better way, I just haven't found it yet.
 	<p>
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{% url 'topic_blog:list_launcher_by_slug' page.slug|default:'--sans-slug--' %}">Liste</a>
-	    {% if page.publication_date %}
-	    	publiée {{ page.publication_date|date:"l d-m-Y" }} par {{ page.publisher.email }}
-	    {% else %}
-			{% if page.first_publication_date %}
-				publiée {{ page.first_publication_date|date:"l d-m-Y" }} par {{ page.publisher.email }} (retirée)
-			{% else %}
-				(brouillon)
-			{% endif %}
-			{% if page.is_publishable %}
-				<form
-				action="{% url 'topicblog:view_launcher_by_pkid' pkid page.slug|default:'--sans-slug--' %}"
-				method="POST">
-					{% csrf_token %}
-					<input type="submit" class="btn btn-outline-info btn-sm" value="Publier">
-				</form>
-			{% endif %}
-	    {% endif %}
 
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{{ page.get_edit_url }}">Modifier</a>
-
-	    {% if page.publication_date %}
-	    <a type="button" class="btn btn-outline-info btn-sm"
-	       href="{% url 'topic_blog:view_launcher_by_slug' page.slug|default:'--sans-slug--' %}">Visualiser (usager)</a>
-	    {% if page.servable %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Retirer</a>
-	    {% else %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Republier</a>
-	    {% endif %}{% endif %}
 	</p>
     </div>
 </div>


### PR DESCRIPTION
TBLa aren't self served pages that require a publication to be
displayed. Instead of that, they are rendered using the `launcher`
templatetag.

Closes #602

On a side note, we might want in the future to have buttons to "activate" the display of the template but that's another for another PR. 
For now, keeping the code related to publication doesn't seem relevant in the context of TBLa.