### PR TITLE
Fix CTA links in mail-client rendered TBEmails

### DIFF
--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -40,14 +40,20 @@ def email_body_text_md(text: str) -> str:
     return mark_safe(html_template)
 
 
-@register.simple_tag
-def email_cta_button(slug: str, label: str) -> str:
+@register.simple_tag(takes_context=True)
+def email_cta_button(context: dict, slug: str, label: str) -> str:
+    tbe_path = reverse_lazy(
+        "topicblog:view_item_by_slug",
+        kwargs={"the_slug": slug}
+    )
+    host = context["request"].get_host()
+    scheme = context["request"].scheme
     html_template = """
     <tr>
         <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
         background-color:#ffffff;text-align:center;">
             <p>
-                <a href="{slug}" class="btn
+                <a href="{scheme}://{host}{tbe_path}" class="btn
                 donation-button btn-lg">
                 {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
                 </a>
@@ -55,7 +61,8 @@ def email_cta_button(slug: str, label: str) -> str:
         </td>
     </tr>
     """.format(
-        slug=reverse_lazy("topic_blog:view_item_by_slug", args=[slug]),
-        label=label
-        )
+        scheme=scheme,
+        host=host,
+        tbe_path=tbe_path,
+        label=label)
     return mark_safe(html_template)

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -1,10 +1,12 @@
 from django.conf import settings
+from django.http import HttpRequest
 from django.template import Template, Context
 from django.test import TestCase
 from django.urls import reverse_lazy
 from django.contrib.auth.models import User
-from topicblog.models import TopicBlogItem,TopicBlogLauncher
+from topicblog.models import TopicBlogItem, TopicBlogLauncher
 from datetime import datetime, timezone
+
 
 class TBEmailTemplateTagsTests(TestCase):
 
@@ -74,7 +76,7 @@ class TBEmailTemplateTagsTests(TestCase):
             <td style="padding-right:30px;padding-left:30px;padding-bottom:15px;
             background-color:#ffffff;text-align:center;">
                 <p>
-                    <a href="{slug}" class="btn
+                    <a href="http://127.0.0.1:8000{slug}" class="btn
                     donation-button btn-lg">
                     {label} <i class="fa fa-arrow-right" area-hidden="true"></i>
                     </a>
@@ -89,7 +91,15 @@ class TBEmailTemplateTagsTests(TestCase):
         template_string = (
             "{% load email_tags %}"
             "{% email_cta_button slug label %}")
-        context = Context({"slug": slug, "label": label})
+
+        def mock_get_host():
+            return "127.0.0.1:8000"
+        http_request = HttpRequest()
+        http_request.get_host = mock_get_host
+        context = Context(
+            {
+                "slug": slug, "label": label, "request": http_request
+            })
         rendered_template = Template(template_string).render(context)
         # Get rid of the whitespaces
         rendered_template = " ".join(rendered_template.split())


### PR DESCRIPTION
Links used to not have scheme and host and would look like this:
`/tb/t/<the_slug>/`
This doesn't parse outside of our website.
Adding the scheme and host allows us to have complete links that are
understandable outside of our website's context e.g.:
`https://www.mobilitains.fr/tb/t/<the_slug>/`

Closes #596

tested on beta, works fine !