### PR TITLE
Add fade-out effect on new index and center button

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -435,7 +435,10 @@ span.centered {
     margin: 2px;
     padding: 4px;
 }
-
+.teaser-text {
+    -webkit-mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+}
 .higlighted-blue {
     font-weight: bold;
     background-color: var(--mobilitains-bleu);

--- a/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
+++ b/transport_nantes/topicblog/templates/topicblog/template_tags/item_teaser.html
@@ -6,7 +6,7 @@
            <p class="card-text text-white">{{ item.header_description }}</p>
          </div>
     </div>
-    <div class="p-4">
+    <div class="p-4 d-flex flex-column">
       {% comment %}
         If the launcher slug does not reference a launcher in the
         database or doesn't have a teaser_words set we display
@@ -15,9 +15,9 @@
         the entire page fail.
       {% endcomment %}
       {% if launcher.teaser_words %}
-        <p>{{ item.body_text_1_md|truncatewords:launcher.teaser_words }}</p>
+        <p class="teaser-text">{{ item.body_text_1_md|truncatewords:launcher.teaser_words }}</p>
       {% else %}
-        <p>{{ item.body_text_1_md|truncatewords:50 }}</p>
+        <p class="teaser-text">{{ item.body_text_1_md|truncatewords:50 }}</p>
       {% endif %}
 		{% comment %}
 	    If the launcher slug does not reference a launcher in the
@@ -32,9 +32,9 @@
 	    no argument, and so 500.
 	  {% endcomment %} 
     {% if item.slug %}
-      <a href="{% url 'topic_blog:view_item_by_slug' item.slug %}" class="btn donation-button btn-lg" >en lire plus <i class="fa fa-arrow-right"></i></a>
+      <a href="{% url 'topic_blog:view_item_by_slug' item.slug %}" class="btn donation-button btn-lg mx-auto" >En lire plus <i class="fa fa-arrow-right"></i></a>
     {% else %}
       404
-    {%endif %}
+    {% endif %}
     </div>
 </div>

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -170,13 +170,13 @@ class TBItemTeaserTemplateTagsTests(TestCase):
     def test_item_teaser(self):
         url = reverse_lazy("topic_blog:view_item_by_slug",
                            args=[self.item.slug])
-        link = f'<a href="{url}" class="btn donation-button btn-lg" >'
+        link = f'<a href="{url}"'
         title = \
             f'<h2 class="card-title text-white">{self.item.header_title}</h2>'
         item_description = self.item.header_description
         description = \
             f'<p class="card-text text-white">{item_description}</p>'
-        text = f'<p>{ self.item.body_text_1_md}</p>'
+        text = f'<p class="teaser-text">{ self.item.body_text_1_md}</p>'
         template_string = (
             "{% load launcher %}"
             "{% item_teaser slug %}")


### PR DESCRIPTION
Draft because failing test

The fade-out suggests that there is more to the story, and I think
encourage the user to read want to read more.
I've no studies to support that assumption, however this is a very
common pattern in news websites.

The centered button feels more natural to me.

This visual improvement has been inspired by the news website I browse, and social medias : You are usually shown just enough to make you want to click, while the text fades out. 

Examples:
![image](https://user-images.githubusercontent.com/70256364/160563991-ab812082-0c3c-45ce-9685-19e32f8cc6a2.png)
![image](https://user-images.githubusercontent.com/70256364/160564110-771b7a43-6117-4775-9a00-f7e4b8a89b52.png)
![image](https://user-images.githubusercontent.com/70256364/160564207-4c67b78f-8c70-4b3c-933f-16e991799ab8.png)

So my proposition for this :

![image](https://user-images.githubusercontent.com/70256364/160565087-5f02cf60-65a1-4007-a70c-a4a300e04882.png)
![image](https://user-images.githubusercontent.com/70256364/160565191-560287f8-ae8f-4708-8c27-3e7d73614ed7.png)