### PR TITLE
Improve pressmention saving

### DIFF
--- a/transport_nantes/press/models.py
+++ b/transport_nantes/press/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.urls import reverse
+from urllib.parse import urlparse
 
 
 class PressMention(models.Model):
@@ -24,3 +26,9 @@ class PressMention(models.Model):
 
     def __str__(self):
         return f"{self.newspaper_name} {self.article_title}"
+
+    def get_absolute_url(self):
+        return reverse("press:detail_item", kwargs={"pk": self.pk})
+
+    def get_domaine_of_link(self):
+        return urlparse(self.article_link).netloc

--- a/transport_nantes/press/templates/press/press_detail.html
+++ b/transport_nantes/press/templates/press/press_detail.html
@@ -1,0 +1,40 @@
+{% extends 'asso_tn/base_mobilitain.html' %}
+{% block content %}
+<div class="container-fluid pl-5 py-3">
+    <div>
+        <a href="{% url 'press:new_item' %}" class="btn btn-outline-info mb-3">
+            <i class="fas fa-plus"></i>
+        </a>
+        <a href="{% url 'press:list_items' %}" class="btn btn-outline-info mb-3">
+            <i class="fas fa-list"></i>
+        </a>
+    </div>
+    <div class="row">
+        <div class="card mb-3 p-0 col-6 col-md-4">
+            <div class="row no-gutters">
+                <div class="col-md-4">
+                    <img src="{{ object.og_image.url }}" style="object-fit: cover;width: 100%;height: 250px;
+                    " class="card-img" alt="{{ object.newspaper_name }}">
+                </div>
+                <div class="col-md-8">
+                    <div class="card-body">
+                        <a href="{{ object.article_link }}" class="stretched-link text-muted text-decoration-none font-weight-bold">{{ object.get_domaine_of_link }}</a>
+                        <h5 class="card-title">{{ object.og_title }}</h5>
+                        <p class="card-text">{{ object.og_description|truncatewords:50 }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="card mb-3 p-0 col-6 col-md-4">
+            <img src="{{ object.og_image.url }}" class="card-img" alt="{{ object.newspaper_name }}">
+            <div class="card-body">
+                <a href="{{ object.article_link }}" class="stretched-link text-muted text-decoration-none font-weight-bold">{{ object.get_domaine_of_link }}</a>
+                <h5 class="card-title">{{ object.og_title }}</h5>
+                <p class="card-text">{{ object.og_description|truncatewords:50 }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/transport_nantes/press/templates/press/press_list.html
+++ b/transport_nantes/press/templates/press/press_list.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <div class="container-fluid pl-5 py-3">
+	<a href="{% url 'press:new_item' %}" class="btn btn-outline-info mb-3"><i class="fas fa-plus"></i></a>
 	{% include 'press/table_list.html' %}
 	<nav aria-label="pagination naviguation">
 		<ul class="pagination justify-content-center">

--- a/transport_nantes/press/tests.py
+++ b/transport_nantes/press/tests.py
@@ -15,6 +15,9 @@ class PressMentionTestCase(TestCase):
             article_title="titre",
             article_summary="description",
             article_publication_date=datetime.now(timezone.utc),
+            og_title="og title",
+            og_description="og description",
+            og_image="image.png",
         )
         self.journal_report_1 = PressMention.objects.create(
             newspaper_name="journal 1",
@@ -22,6 +25,9 @@ class PressMentionTestCase(TestCase):
             article_title="titre 1",
             article_summary="description 1",
             article_publication_date=datetime.now(timezone.utc),
+            og_title="og title 1",
+            og_description="og description 1",
+            og_image="image1.png",
         )
         self.user = User.objects.create_user(username='user',
                                              password='password')
@@ -188,3 +194,27 @@ class PressMentionTestCase(TestCase):
                          " des périphéries.")
         self.assertIn("pont-rousseau-1", new_press_mention.og_image.url)
         self.assertIn(".jpg", new_press_mention.og_image.url)
+
+    def test_detail_view_press(self):
+        """Only user with press-editor permission should have access to this page
+            For this test we use a list of dictionaries, that is composed of:
+            - client = the client of user (auth user, unauth and permited user)
+            - code = the excepted statut code
+            - message = the error message"""
+        users_expected = [
+            {"client": self.client, "code": 403,
+             "msg": "Auth user without permission can't access to this page"},
+            {"client": self.unauth_client, "code": 302,
+             "msg": "Unauth user have access to create view."},
+            {"client": self.user_permited_client, "code": 200,
+             "msg": "Auth user with permission have access to create view"},
+        ]
+        for user_type in users_expected:
+            response = \
+                user_type["client"].get(reverse(
+                    "press:detail_item",
+                    kwargs={
+                        "pk": self.journal_report.id,
+                    }))
+            self.assertEqual(response.status_code,
+                             user_type["code"], msg=user_type["msg"])

--- a/transport_nantes/press/tests.py
+++ b/transport_nantes/press/tests.py
@@ -1,7 +1,6 @@
 from django.test import TestCase, Client
 from .models import PressMention
-from topicblog.models import TopicBlogItem
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from django.contrib.auth.models import User, Permission
 from django.urls import reverse
 

--- a/transport_nantes/press/urls.py
+++ b/transport_nantes/press/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import (PressMentionListViewAdmin, PressMentionUpdateView,
                     PressMentionListView, PressMentionCreateView,
-                    PressMentionDeleteView)
+                    PressMentionDeleteView, PressMentionDetailView)
 
 app_name = 'press'
 
@@ -11,4 +11,5 @@ urlpatterns = [
     path('new/', PressMentionCreateView.as_view(), name='new_item'),
     path('update/<int:pk>', PressMentionUpdateView.as_view(), name='update_item'),
     path('delete/<int:pk>', PressMentionDeleteView.as_view(), name='delete_item'),
+    path('detail/<int:pk>', PressMentionDetailView.as_view(), name='detail_item'),
 ]

--- a/transport_nantes/press/views.py
+++ b/transport_nantes/press/views.py
@@ -1,4 +1,5 @@
-from django.views.generic import ListView, CreateView, UpdateView, DeleteView
+from django.views.generic import (ListView, CreateView, UpdateView,
+                                  DeleteView, DetailView)
 from .models import PressMention
 from django.urls import reverse_lazy
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -49,7 +50,6 @@ class PressMentionListViewAdmin(PermissionRequiredMixin, ListView):
 class PressMentionCreateView(PermissionRequiredMixin, CreateView):
     template_name = "press/press_create.html"
     form_class = PressMentionForm
-    success_url = reverse_lazy('press:new_item')
     permission_required = 'press.press-editor'
 
     def get_context_data(self, **kwargs):
@@ -100,4 +100,10 @@ class PressMentionDeleteView(PermissionRequiredMixin, DeleteView):
     model = PressMention
     template_name = "press/press_delete.html"
     success_url = reverse_lazy('press:list_items')
+    permission_required = 'press.press-editor'
+
+
+class PressMentionDetailView(PermissionRequiredMixin, DetailView):
+    model = PressMention
+    template_name = "press/press_detail.html"
     permission_required = 'press.press-editor'


### PR DESCRIPTION
Based on [PR](https://github.com/transport-nantes/tn_web/pull/631)
-  Saving a valid  press_mention now redirect to press:detail_item
- Add test for press:detail_item page
- Clean unused import

On the detail view, I left 2 display options