### PR TITLE
Update display press mention and dashboard

### DIFF
--- a/transport_nantes/dashboard/templates/dashboard/index.html
+++ b/transport_nantes/dashboard/templates/dashboard/index.html
@@ -30,10 +30,10 @@
 		<div class="col-sm-6">
 			<h3>Press</h3>
 			<p>Les articles qui mentionnent les mobilitains</p>
-			<p>
-				<a class="nav-link" href="{% url 'press:new_item' %}">Créer un nouveu</a>
-				<a class="nav-link" href="{% url 'press:list_items' %}">Voir la liste</a>
-			</p>
+			<div class="d-flex justify-content-start">
+				<a class="nav-link" href="{% url 'press:list_items' %}"><i class="fas fa-list"></i></a>
+				<a class="nav-link" href="{% url 'press:new_item' %}"><i class="fas fa-plus"></i></a>
+			</div>
 		</div>
 	</div>
 </div>

--- a/transport_nantes/press/templates/press/press_detail.html
+++ b/transport_nantes/press/templates/press/press_detail.html
@@ -2,19 +2,19 @@
 {% block content %}
 <div class="container-fluid pl-5 py-3">
     <div>
+        <a href="{% url 'press:list_items' %}" class="btn btn-outline-info mb-3" data-toggle="tooltip" data-placement="bottom" title="Voir la liste des articles de presse">
+            <i class="fa fa-arrow-left"></i>
+        </a>
         <a href="{% url 'press:new_item' %}" class="btn btn-outline-info mb-3" data-toggle="tooltip" data-placement="bottom" title="Ajouter un nouvel article de presse">
             <i class="fas fa-plus"></i>
-        </a>
-        <a href="{% url 'press:list_items' %}" class="btn btn-outline-info mb-3" data-toggle="tooltip" data-placement="bottom" title="Voir la liste des articles de presse">
-            <i class="fas fa-list"></i>
         </a>
     </div>
     <div class="row">
         <div class="card mb-3 p-0 col-12 col-md-6">
             <div class="row no-gutters">
                 <div class="col-md-4">
-                    <img src="{{ object.og_image.url }}" style="object-fit: cover;width: 100%;height: 250px;
-                    " class="card-img" alt="{{ object.newspaper_name }}">
+                    <img src="{{ object.og_image.url }}" style="object-fit: cover;width: 100%;height: 250px;"
+                         class="card-img" alt="{{ object.newspaper_name }}">
                 </div>
                 <div class="col-md-8">
                     <div class="card-body">

--- a/transport_nantes/press/templates/press/table_list.html
+++ b/transport_nantes/press/templates/press/table_list.html
@@ -40,6 +40,7 @@
           {% endif %}
         <td>{{ press_mention.article_publication_date|date:"d/m/Y" }}</td>
         <td>
+          <a href="{% url 'press:detail_item' press_mention.id%} " class="btn navigation-button m-1"><i class="fas fa-eye"></i></a>
           <a href="{% url 'press:update_item' press_mention.id%}" class="btn navigation-button m-1"><i class="fas fa-edit"></i></a>
           <a href="{% url 'press:delete_item' press_mention.id%} " class="btn navigation-button m-1"><i class="fa fa-trash"></i></a>
         </td>
@@ -66,7 +67,10 @@
         <p>Pas d'image</p>
       {% endif %}
     </div>
-    <a href="{% url 'press:update_item' press_mention.id%}"><i class="fas fa-edit"></i></a>
-    <a href="{% url 'press:delete_item' press_mention.id%}"><i class="fa fa-trash"></i></a>
+    <div class="d-flex justify-content-around">
+      <a href="{% url 'press:detail_item' press_mention.id%}"><i class="fas fa-eye"></i></a>
+      <a href="{% url 'press:update_item' press_mention.id%}"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'press:delete_item' press_mention.id%}"><i class="fa fa-trash"></i></a>
+    </div>
   </div>
 {% endfor %}


### PR DESCRIPTION
I have a question on the [issue ](https://github.com/transport-nantes/tn_web/issues/661#issuecomment-1093288064)
- Update use icon for display pressmention page
- Add link to the detail view on table list template
-  Update turn the list icon into arrow left icon