### PR TITLE
Enable I18N to display date in French

### DIFF
--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -183,7 +183,7 @@ LOGGING = {
 
 LANGUAGE_CODE = 'fr'
 TIME_ZONE = 'UTC'
-USE_I18N = False
+USE_I18N = True
 USE_L10N = False
 USE_TZ = True
 # TODO: stay on same page if authorised to do so.


### PR DESCRIPTION
The LANGUAGE_CODE setting has no effect while the I18N is disabled.
See doc :
https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-LANGUAGE_CODE

Closes #674