### PR TITLE
Fix default login URL

### DIFF
--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
+from django.urls import reverse_lazy
 from . import settings_local
 import sys
 
@@ -196,6 +197,7 @@ USE_L10N = False
 USE_TZ = True
 # TODO: stay on same page if authorised to do so.
 LOGIN_REDIRECT_URL = 'index'
+LOGIN_URL = reverse_lazy('authentication:login')
 #LOGOUT_REDIRECT_URL = 'index'
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
The default setting doesn't match our app's path, so we need to set it.
This is the origin of the 404 page shown when redirected to login.

Closes #692