### PR TITLE
Improve Launchers responsive

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -560,3 +560,23 @@ span.centered {
 .text-utm {
     font-size: 75%;
 }
+.tbla-container {
+    position: relative;
+    width: 100%; /* The size you want */
+}
+.tbla-container:after {
+    content: "";
+    display: block;
+    padding-bottom: 100%; /* The padding depends on the width, not on the height, so with a padding-bottom of 100% you will get a square */
+}
+.tbla-container img {
+    position: absolute; /* Take your picture out of the flow */
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0; /* Make the picture taking the size of it's parent */
+    width: 100%; /* This if for the object-fit */
+    height: 100%; /* This if for the object-fit */
+    object-fit: cover; /* Equivalent of the background-size: cover; of a background-image */
+    object-position: center;
+}

--- a/transport_nantes/topicblog/templates/topicblog/template_tags/launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/template_tags/launcher.html
@@ -11,10 +11,10 @@
 	    Note that it would be worse than linking to nowhere: the
 	    reverse url lookup would see an empty argument, conclude
 	    no argument, and so 500.
-	        {% endcomment %} {% if launcher.article_slug %}<a href="{% url 'topic_blog:view_item_by_slug' launcher.article_slug %}">{% else %} 404 {% endif %}
-			<div class="shadow-md">
-				<img class="rounded" src="{{ launcher.launcher_image.url }}" alt="{{ launcher.launcher_image_alt_text }}" width="435" height="435"
-				style="object-fit: cover; max-width: 100%; max-height:30vh;">
+	    {% endcomment %} 
+			{% if launcher.article_slug %}<a href="{% url 'topic_blog:view_item_by_slug' launcher.article_slug %}">{% else %} 404 {% endif %}
+			<div class="shadow-md tbla-container">
+				<img class="rounded" src="{{ launcher.launcher_image.url }}" alt="{{ launcher.launcher_image_alt_text }}">
 			</div>
 			<div class="caption pt-2">
 				<h3 class="font-weight-light">{{ launcher.headline }}</h3>


### PR DESCRIPTION
The images used to stretch thin, but now keep the same aspect ratio
no matter the size of the screen.