### PR TITLE
Make same_slug_warning adapt on the model we're using

### DIFF
--- a/transport_nantes/topicblog/static/topicblog/same_slug_warning.js
+++ b/transport_nantes/topicblog/static/topicblog/same_slug_warning.js
@@ -1,8 +1,13 @@
 // Calls server to get a list of all slugs and
 // how many of each slug there are.
+const MODEL_NAME = JSON.parse(document.getElementById('model_name').textContent);
+
 async function get_slug_dict() {
     data = await $.ajax({
         url: '/tb/ajax/get-slug-dict/',
+        data: {
+            model_name: MODEL_NAME
+        },
     })
     return data;
 }

--- a/transport_nantes/topicblog/templates/topicblog/topicblogbase_edit.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogbase_edit.html
@@ -33,6 +33,8 @@ This particular instance is used to get the ids of the slug fields in the form.
 It is retrieved inside clean_slug_field.js
 {% endcomment %}
 {{slug_fields|json_script:"slug_fields"}}
+{# The model name is used to warn the user about the number of same slug items in this model #}
+{{ model_name|json_script:"model_name" }}
 
 <div class="d-flex col-12 col-sm-10 col-lg-8 flex-column justify-content-center mx-auto">
 	<h2 class="text-center">{{ tb_object.description_of_object }}</h2>

--- a/transport_nantes/topicblog/tests_topic_blog.py
+++ b/transport_nantes/topicblog/tests_topic_blog.py
@@ -884,7 +884,10 @@ class TBIView(TestCase):
     def test_get_slug_dict(self):
         for user_type in self.users_expected:
             response = user_type["client"].get(
-                reverse('topicblog:get_slug_dict')
+                reverse('topicblog:get_slug_dict',),
+                data={
+                    'model_name': 'TopicBlogItem'
+                }
             )
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -120,10 +120,13 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 PASSWORD_RESET_TIMEOUT_DAYS = 1
 
-if ROLE == 'dev':
+if 'EMAIL_BACKEND' in settings_local.__dict__:
+    EMAIL_BACKEND = settings_local.EMAIL_BACKEND
+elif ROLE == 'dev':
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 else:
     EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
+
 AWS_ACCESS_KEY_ID = settings_local.AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY = settings_local.AWS_SECRET_ACCESS_KEY
 AWS_DEFAULT_REGION = settings_local.AWS_DEFAULT_REGION


### PR DESCRIPTION
Based on PR #712 

The JS used to request only TopicBlogItems slugs.
Now that we're using several models, we're requesting slugs for the
model we're using.

Closes #700