### PR TITLE
Allow admin panel to filter by and search by email instead of username

### DIFF
--- a/transport_nantes/photo/admin.py
+++ b/transport_nantes/photo/admin.py
@@ -6,8 +6,8 @@ class PhotoEntryAdmin(admin.ModelAdmin):
     readonly_fields = ('pk',)
 
     list_display = ("category", "user")
-    list_filter = ("category", "user")
-    search_fields = ("category", "user")
+    list_filter = ("category", "user__email")
+    search_fields = ("category", "user__email")
 
 
 admin.site.register(PhotoEntry, PhotoEntryAdmin)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70256364/166661716-f0cfd8a9-08fb-4765-86af-b0067bd33d22.png)

The column display can't be user.email afaik, maybe there is a way, but considering this is low priority, I guess this is better than the default 