### PR TITLE
Fix TopicBlogLauncher preview

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/content_launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_launcher.html
@@ -6,8 +6,8 @@
     <p>Cette page n'est pas privée mais n'est pas destinée au public.
 	Elle peut disparaître du jour au lendemain.
     </p>
-    {% launcher page.slug %}
+    {% launcher page.slug is_preview=True%}
     <hr>
-    {% item_teaser page.slug %}
+    {% item_teaser page.slug is_preview=True %}
 </div>
 {% endblock content %}

--- a/transport_nantes/topicblog/templates/topicblog/template_tags/launcher.html
+++ b/transport_nantes/topicblog/templates/topicblog/template_tags/launcher.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <div class="col-md-3">
 	<div class="thumbnail">
 		{% comment %}
@@ -14,7 +16,11 @@
 	    {% endcomment %} 
 			{% if launcher.article_slug %}<a href="{% url 'topic_blog:view_item_by_slug' launcher.article_slug %}">{% else %} 404 {% endif %}
 			<div class="shadow-md tbla-container">
-				<img class="rounded" src="{{ launcher.launcher_image.url }}" alt="{{ launcher.launcher_image_alt_text }}">
+				{% if launcher.launcher_image %}
+					<img class="rounded" src="{{ launcher.launcher_image.url }}" alt="{{ launcher.launcher_image_alt_text }}">
+				{% else %}
+					<img class="rounded" src="{% static 'asso_tn/beacon.gif' %}" alt="No image provided">
+				{% endif %}
 			</div>
 			<div class="caption pt-2">
 				<h3 class="font-weight-light">{{ launcher.headline }}</h3>


### PR DESCRIPTION
The template used to display the published item if any, even when
we requested a single item.

To not have to maintain a separate version of the template tag,
I added a "preview" flag that is set in the template that is used to
display the previews.
The index template doesn't and must not carry this flag, as the "page"
context variable is very different in this context.

Also added a fallback to help visualize if no image is provided.