### PR TITLE
Benja 714 sns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+amqp==5.1.1
 appdirs==1.4.3
 asgiref==3.4.1
 astroid==2.5.6
 async-generator==1.10
+async-timeout==4.0.2
 attrs==21.4.0
 autopep8==1.5.7
 awscli==1.19.59
@@ -15,13 +17,18 @@ certifi==2019.11.28
 cffi==1.15.0
 chardet==3.0.4
 charset-normalizer==2.0.6
+click==8.1.3
+click-didyoumean==0.3.0
+click-plugins==1.1.1
+click-repl==0.2.0
 colorama==0.4.3
 configparser==5.2.0
 contextlib2==0.6.0
 coverage==6.3.1
 crayons==0.4.0
-cryptography==36.0.1
+cryptography==36.0.2
 decorator==4.4.1
+Deprecated==1.2.13
 distlib==0.3.0
 distro==1.4.0
 Django==4.0.4
@@ -30,6 +37,7 @@ django-countries==7.2.1
 django-crispy-forms==1.14.0
 django-debug-toolbar==3.2.4
 django-ranged-response==0.2.0
+django-ses==3.0.1
 django-simple-captcha==0.5.13
 dj-stripe==2.5.1
 docutils==0.15.2
@@ -47,6 +55,7 @@ jedi==0.16.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsonfield==3.1.0
+kombu==5.2.4
 lazy-object-proxy==1.6.0
 lockfile==0.12.2
 lxml==4.8.0
@@ -82,7 +91,7 @@ python-http-client==3.2.7
 pytoml==0.1.21
 pytz==2019.3
 PyYAML==5.4.1
-requests==2.26.0
+requests==2.27.1
 retrying==1.3.3
 rsa==4.7
 s3transfer==0.4.2
@@ -99,6 +108,7 @@ trio-websocket==0.9.2
 ua-parser==0.10.0
 urllib3==1.26.5
 user-agents==2.2.0
+vine==5.0.0
 wcwidth==0.1.8
 webdriver-manager==3.5.2
 webencodings==0.5.1

--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -152,11 +152,22 @@ def prepare_email(email: str, request: HttpRequest) \
         "host": get_current_site(request).domain,
     }
     html_message = render_to_string(template, context=context, request=request)
+    # AWS SES reads the headers to check the presence of a configuration set.
+    # If one is found, the configuration set allows notifications
+    # regarding the email to be sent to the endpoints set in AWS (i.e. emails,
+    # https, etc ...).
+    # Depending on the event received (i.e. Bounce, delivery, rejected...),
+    # different endpoints can be notified.
+    # Without this header, the email is sent but no notification will be sent
+    # to the endpoints.
+    AWS_headers = {
+        "X-SES-CONFIGURATION-SET": settings.AWS_CONFIGURATION_SET_NAME}
     email = EmailMultiAlternatives(
         subject='Votre lien de connexion à Mobilitains.fr',
         body=render_to_string(template, context),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[email],
+        headers=AWS_headers,
     )
     email.attach_alternative(html_message, 'text/html')
 

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -390,11 +390,23 @@ class SendableObjectMixin:
         # message is displayed in the mail client.
         plain_text_message = strip_tags(html_message)
 
+        # AWS SES reads the headers to check the presence of a configuration
+        # set. If one is found, the configuration set allows notifications
+        # regarding the email to be sent to the endpoints set in AWS (i.e.
+        # emails, https, etc ...).
+        # Depending on the event received (i.e.Bounce, delivery, rejected...),
+        # different endpoints can be notified.
+        # Without this header, the email is sent but no notification will be
+        # sent to the endpoints.
+        AWS_headers = {
+            "X-SES-CONFIGURATION-SET": settings.AWS_CONFIGURATION_SET_NAME}
+
         email = mail.EmailMultiAlternatives(
             subject=tb_object.subject,
             body=plain_text_message,
             from_email=from_email,
             to=recipient_list,
+            headers=AWS_headers,
         )
         email.attach_alternative(html_message, "text/html")
 

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -130,6 +130,7 @@ else:
 AWS_ACCESS_KEY_ID = settings_local.AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY = settings_local.AWS_SECRET_ACCESS_KEY
 AWS_DEFAULT_REGION = settings_local.AWS_DEFAULT_REGION
+AWS_SES_REGION_ENDPOINT_URL = 'email.eu-central-1.amazonaws.com'
 DEFAULT_FROM_EMAIL = settings_local.DEFAULT_FROM_EMAIL
 
 LOGGING = {

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -149,6 +149,11 @@ LOGGING = {
             '()': 'django.utils.log.ServerFormatter',
             'format': '[{server_time}] {message}',
             'style': '{',
+        },
+        'django.ses.extra': {
+            '()': 'django.utils.log.ServerFormatter',
+            'format': '[{server_time}] {message}  Notification : {notification}',
+            'style': '{',
         }
     },
     'handlers': {
@@ -172,6 +177,12 @@ LOGGING = {
             'class': 'logging.FileHandler',
             'filename': settings_local.LOG_DIR + "tn_web.log",
             'formatter': 'django.server',
+        },
+        'django_ses_notification': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': settings_local.LOG_DIR + "tn_web-ses.log",
+            'formatter': 'django.ses.extra',
         }
     },
     'loggers': {
@@ -191,6 +202,11 @@ LOGGING = {
             'handlers': ['django.server'],
             'level': 'INFO',
             'propagate': False,
+        },
+        'django_ses': {
+            'handlers': ['console', 'django_ses_notification'],
+            'level': 'INFO',
+            'propagate': True,
         },
     }
 }

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -132,6 +132,8 @@ AWS_SECRET_ACCESS_KEY = settings_local.AWS_SECRET_ACCESS_KEY
 AWS_DEFAULT_REGION = settings_local.AWS_DEFAULT_REGION
 AWS_SES_REGION_ENDPOINT_URL = 'email.eu-central-1.amazonaws.com'
 DEFAULT_FROM_EMAIL = settings_local.DEFAULT_FROM_EMAIL
+AWS_CONFIGURATION_SET_NAME = getattr(
+    settings_local, "AWS_CONFIGURATION_SET_NAME", "placeholder123")
 
 LOGGING = {
     'version': 1,

--- a/transport_nantes/transport_nantes/urls.py
+++ b/transport_nantes/transport_nantes/urls.py
@@ -20,6 +20,7 @@ from topicblog.views import TopicBlogItemView
 from django.conf import settings
 from django.conf.urls.static import static
 from transport_nantes.settings import ROLE
+from django_ses.views import SESEventWebhookView
 
 urlpatterns = [
     path('', TopicBlogItemView.as_view(),
@@ -51,6 +52,8 @@ urlpatterns = [
     path("presse/", include('press.urls')),
     path("photo/", include('photo.urls')),
     path('__debug__/', include('debug_toolbar.urls')),
+    path("ses/event-webhook/", SESEventWebhookView.as_view(),
+         name="ses_event_webhook"),
 ]
 
 if ROLE != 'production':


### PR DESCRIPTION
Edit : The GiotHub Action config file doesn't include the AWS_CONFIGURATION_SET_NAME in settings_local.py, this is blocking and would also be blocking on infra while this isn't the case. 

This PR adds the webhook and configuration needed to catch and handle events coming from Amazon SES.

The configuration set added in the email's header tells AWS how to handle the notifications regarding this email.

I'm not sure about the risk of leaking the name of the configuration set ? I don't think anyone could do something with it unless they also have our credentials, so if it's alright, I could add to our settings_local template the configuration_set of beta. 

A written document is on the way about how to add your own configuration set. 