### PR TITLE
Upgrade from django 3.2 to django 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ attrs==21.4.0
 autopep8==1.5.7
 awscli==1.19.59
 backcall==0.1.0
+backports.zoneinfo==0.2.1
 boto3==1.17.59
 botocore==1.20.59
 branca==0.4.2
@@ -23,10 +24,10 @@ cryptography==36.0.1
 decorator==4.4.1
 distlib==0.3.0
 distro==1.4.0
-Django==3.2.13
+Django==4.0.4
 django-amazon-ses==4.0.0
 django-countries==7.2.1
-django-crispy-forms==1.12.0
+django-crispy-forms==1.14.0
 django-debug-toolbar==3.2.4
 django-ranged-response==0.2.0
 django-simple-captcha==0.5.13

--- a/transport_nantes/utm/tests.py
+++ b/transport_nantes/utm/tests.py
@@ -2,21 +2,25 @@ from django.test import TestCase
 from .models import UTM
 from django.utils.crypto import get_random_string
 
+# This is used for creating probably distinct test values.
+# It has no other real significance in this test.
+k_string_length = 12
+
 class SimpleTest(TestCase):
     def setUp(self):
         pass
 
     def test_parse_url_ads_true(self):
-        the_campaign = get_random_string()
-        the_content = get_random_string()
-        the_medium = get_random_string()
-        the_source = get_random_string()
-        the_term = get_random_string()
-        the_aclk = get_random_string()
-        the_fbclid = get_random_string()
-        the_gclid = get_random_string()
-        the_msclkid = get_random_string()
-        the_twclid = get_random_string()
+        the_campaign = get_random_string(k_string_length)
+        the_content = get_random_string(k_string_length)
+        the_medium = get_random_string(k_string_length)
+        the_source = get_random_string(k_string_length)
+        the_term = get_random_string(k_string_length)
+        the_aclk = get_random_string(k_string_length)
+        the_fbclid = get_random_string(k_string_length)
+        the_gclid = get_random_string(k_string_length)
+        the_msclkid = get_random_string(k_string_length)
+        the_twclid = get_random_string(k_string_length)
         url = f"/?a=b&utm_campaign={the_campaign}&utm_medium={the_medium}&utm_content={the_content}&c=1&utm_term={the_term}&utm_source={the_source}&gclid={the_gclid}&fbclid={the_fbclid}&twclid={the_twclid}&msclkid={the_msclkid}&aclk={the_aclk}"
         response = self.client.get(url)
         objects = UTM.objects.all()
@@ -35,11 +39,11 @@ class SimpleTest(TestCase):
         self.assertNotEqual("-", object.session_id)
 
     def test_parse_url_ads_false(self):
-        the_campaign = get_random_string()
-        the_content = get_random_string()
-        the_medium = get_random_string()
-        the_source = get_random_string()
-        the_term = get_random_string()
+        the_campaign = get_random_string(k_string_length)
+        the_content = get_random_string(k_string_length)
+        the_medium = get_random_string(k_string_length)
+        the_source = get_random_string(k_string_length)
+        the_term = get_random_string(k_string_length)
         url = f"/?a=b&utm_campaign={the_campaign}&utm_medium={the_medium}&utm_content={the_content}&c=1&utm_term={the_term}&utm_source={the_source}"
         response = self.client.get(url)
         objects = UTM.objects.all()


### PR DESCRIPTION
This _seems_ to work for me and tests pass.

Mostly, I want to upgrade because it appears to give us a more modern celery version, if I understand correctly what I am reading and I am using pip correctly.

Notes:
* [Upgrading djago](https://docs.djangoproject.com/en/4.0/howto/upgrade-version/)
* [Django 4 release notes](https://docs.djangoproject.com/en/4.0/releases/4.0/)

Closes #745.