### PR TITLE
Benja handle ses events

### DIFF
--- a/transport_nantes/authentication/tests_auth.py
+++ b/transport_nantes/authentication/tests_auth.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 import datetime
 
 from django.urls.base import reverse
@@ -33,7 +33,7 @@ class TimedTokenTest(TestCase):
             self.assertEqual(after_response[1], 0)
 
 
-class LoginViewTest(TestCase):
+class LoginViewTest(TransactionTestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(


### PR DESCRIPTION
Based on #748 

This PR adds the "Sent" even handling.
It also add error handling when sending an email. If the sending is rejected, the send record associated with the email gets a 'FAILED' status, and the rest of emails is processed.

A successfully sent email is properly updated with a "SENT" status, an updated "sent_time" and AWS message id.
