### PR TITLE
improve error handling on Stripe recurring payments

### DIFF
--- a/transport_nantes/stripe_app/tests.py
+++ b/transport_nantes/stripe_app/tests.py
@@ -104,7 +104,7 @@ class StripeAppTests(TestCase):
         response = self.post_payload_to_webhook(
             self.payment_succeeded_sub_cycle_payload)
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 200)
 
         number_of_donations = Donation.objects.count()
         self.assertEqual(number_of_donations, 2)


### PR DESCRIPTION
Recurring payments, need a customer ID that is saved on the original
donation entry.
At some point of our history, the customer_ID wasn't saved so when we
started catching the recurring payments, the database was unable to
tell to which customer the recurring payment belonged to.

Nowadays, we do save the customer id (see commit 1370c32) so this isn't
an issue anymore.

Stripe nonetheless signaled us that it had issues joining our webhook,
that was mainly because all the test customer and payments we did during
the development before the customer_id saving change were trying to
renew the subscription, while their original customer id wasn't saved.

Raising 500 errors on the webhooks was a bad idea, so I decided to log
the errors properly and return a 200.