### PR TITLE
Make beacon_view update the proper send records 

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -13,7 +13,7 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
         {# links will need to be wrapped into redirect links #}
         <a href="{% absolute_url 'topicblog:view_email_by_slug' page.slug|default:email.slug %}" style="font-size:0.7em;color:gray;text-decoration:underline;">Voir sur le site web</a>
     </tr>
-    <img src="{% absolute_url 'topicblog:beacon_view' token %}.gif" alt="space" height="1" width="1">
+    <img src="{% absolute_url 'topicblog:beacon_view' beacon_token %}.gif" alt="space" height="1" width="1">
     <tr>
         {% comment "Logo" %}This row handles the logo display{% endcomment %}
         <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">

--- a/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
@@ -14,7 +14,7 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
             Voir sur le site web
         </a>
     </tr>
-    <img src="{% absolute_url 'topicblog:beacon_view' token %}.gif" alt="space" height="1" width="1">
+    <img src="{% absolute_url 'topicblog:beacon_view' beacon_token %}.gif" alt="space" height="1" width="1">
     <tr>
         {# These rows handle the logo display #}
         <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;background-color:#ffffff;">

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -1184,7 +1184,7 @@ def send_received_handler(sender, mail_obj, send_obj, *args, **kwargs):
 
 
 @receiver(open_received)
-def open_received_handler(sender, mail_obj, send_obj, *args, **kwargs):
+def open_received_handler(sender, mail_obj, open_obj, *args, **kwargs):
     """Handle AWS SES open_received notifications
 
     AWS Receiver
@@ -1207,7 +1207,7 @@ def open_received_handler(sender, mail_obj, send_obj, *args, **kwargs):
 
 
 @receiver(click_received)
-def click_received_handler(sender, mail_obj, send_obj, *args, **kwargs):
+def click_received_handler(sender, mail_obj, click_obj, *args, **kwargs):
     """Handle AWS SES click_received notifications
 
     AWS Receiver


### PR DESCRIPTION
It previously always assumed we were using the TopicBlogEmail send
record.

Using a new token that encodes the send_record_class, we can fetch
the proper send record.

Closes  #799