### PR TITLE
Benja-django-dbbackup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,10 @@ certifi==2019.11.28
 cffi==1.15.0
 chardet==3.0.4
 charset-normalizer==2.0.6
+click==8.1.3
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
-click==8.1.3
 colorama==0.4.3
 configparser==5.2.0
 contextlib2==0.6.0
@@ -34,7 +34,7 @@ decorator==4.4.1
 Deprecated==1.2.13
 distlib==0.3.0
 distro==1.4.0
-dj-stripe==2.5.1
+Django==4.0.4
 django-amazon-ses==4.0.1
 django-countries==7.2.1
 django-crispy-forms==1.14.0
@@ -42,7 +42,7 @@ django-debug-toolbar==3.2.4
 django-ranged-response==0.2.0
 django-ses==3.0.1
 django-simple-captcha==0.5.13
-Django==4.0.4
+dj-stripe==2.5.1
 docutils==0.15.2
 folium==0.12.1
 future==0.18.2
@@ -51,8 +51,8 @@ h11==0.13.0
 html5lib==1.0.1
 idna==2.8
 ipaddr==2.2.0
-ipython-genutils==0.2.0
 ipython==7.16.3
+ipython-genutils==0.2.0
 isort==5.8.0
 jedi==0.16.0
 Jinja2==2.11.3
@@ -73,9 +73,9 @@ parso==0.6.1
 pep517==0.8.2
 pexpect==4.8.0
 pickleshare==0.7.5
+Pillow==9.0.1
 pillow-scripts==5.0.0
 pillow-snippet==0.0.4
-Pillow==9.0.1
 progress==1.5
 prompt-toolkit==3.0.3
 psycopg2==2.8.4
@@ -84,9 +84,9 @@ pyasn1==0.4.8
 pycodestyle==2.7.0
 pycparser==2.21
 Pygments==2.8.1
+pylint==2.8.2
 pylint-django==2.4.4
 pylint-plugin-utils==0.6
-pylint==2.8.2
 pyOpenSSL==22.0.0
 pyparsing==2.4.6
 python-dateutil==2.8.1
@@ -106,8 +106,8 @@ sqlparse==0.3.0
 stripe==2.55.0
 toml==0.10.2
 traitlets==4.3.3
-trio-websocket==0.9.2
 trio==0.19.0
+trio-websocket==0.9.2
 ua-parser==0.10.0
 urllib3==1.26.5
 user-agents==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ Django==4.0.4
 django-amazon-ses==4.0.1
 django-countries==7.2.1
 django-crispy-forms==1.14.0
+django-dbbackup==4.0.0b0
 django-debug-toolbar==3.2.4
 django-ranged-response==0.2.0
 django-ses==3.0.1

--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     'press',
     'debug_toolbar',
     'photo',
+    'dbbackup',  # django-dbbackup
 ] + settings_local.MORE_INSTALLED_APPS
 
 MIDDLEWARE = [
@@ -101,6 +102,10 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 
 DATABASES = settings_local.DATABASES
+
+# Django dbbackup
+DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
+DBBACKUP_STORAGE_OPTIONS = settings_local.DBBACKUP_STORAGE_OPTIONS
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/transport_nantes/transport_nantes/settings_local.py.DEV.template
+++ b/transport_nantes/transport_nantes/settings_local.py.DEV.template
@@ -26,6 +26,10 @@ DATABASES = {
     }
 }
 
+
+DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
+DBBACKUP_STORAGE_OPTIONS = {'location': '/my/backup/dir/'}
+
 LOG_DIR = '/tmp/django-tn-log/'
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')


### PR DESCRIPTION
Draft while it's not been tested at least on beta

This PR adds django-dbbackup, that allows us to dump and restore using management commands. 

Doc : 
https://django-dbbackup.readthedocs.io/en/master/index.html

It can be combined to django-cron but as it's the only command we'd run for now, it's useless to set it up. 