### PR TITLE
Remove references to "servable"

### DIFF
--- a/transport_nantes/topicblog/forms.py
+++ b/transport_nantes/topicblog/forms.py
@@ -13,7 +13,7 @@ class TopicBlogItemForm(ModelForm):
     class Meta:
         model = TopicBlogItem
         # Admins can still edit those values
-        exclude = ('item_sort_key', 'servable', 'user',
+        exclude = ('item_sort_key', 'user',
                    'publication_date', 'first_publication_date', 'publisher')
 
     def __init__(self, *args, **kwargs):

--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -151,8 +151,12 @@ class TopicBlogObjectBase(models.Model):
         else:
             return f'{str(self.title)} - ID : {str(self.id)} (NO SLUG)'
 
-    def get_servable_status(self):
-        """Return True if page is user visible, False otherwise."""
+    def get_servable_status(self) -> bool:
+        """Return True if page is user visible, False otherwise.
+
+        The publication date being set and inferior or equal to same day
+        isn't the only constraint to be user visible, it also need to be
+        the last one published."""
         if self.publication_date is None or \
                 datetime.now(timezone.utc) < self.publication_date:
             return False

--- a/transport_nantes/topicblog/templates/topicblog/base_press.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_press.html
@@ -44,13 +44,7 @@ Maybe there's a better way, I just haven't found it yet.
 	    {% if page.publication_date %}
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{% url 'topic_blog:view_press_by_slug' page.slug|default:'--sans-slug--' %}">Visualiser (usager)</a>
-	    {% if page.servable %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Retirer</a>
-	    {% else %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Republier</a>
-	    {% endif %}{% endif %}
+		{% endif %}
 	</p>
     </div>
 </div>

--- a/transport_nantes/topicblog/templates/topicblog/base_topicblog.html
+++ b/transport_nantes/topicblog/templates/topicblog/base_topicblog.html
@@ -43,13 +43,7 @@ Maybe there's a better way, I just haven't found it yet.
 	    {% if page.publication_date %}
 	    <a type="button" class="btn btn-outline-info btn-sm"
 	       href="{% url 'topic_blog:view_item_by_slug' page.slug|default:'--sans-slug--' %}">Visualiser (usager)</a>
-	    {% if page.servable %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Retirer</a>
-	    {% else %}
-	    <a type="button" class="btn btn-outline-info btn-sm disabled" aria-disabled="true"
-	       href="">Republier</a>
-	    {% endif %}{% endif %}
+	    {% endif %}
 	</p>
     </div>
 </div>


### PR DESCRIPTION
We don't use this attribute anymore. Its presence in templates showed
buttons that had no functionality.

Closes #462