### PR TITLE
Log what we do in photo upload

### DIFF
--- a/transport_nantes/photo/views.py
+++ b/transport_nantes/photo/views.py
@@ -30,12 +30,14 @@ class UploadEntry(LoginRequiredMixin, CreateView):
         form.instance.user = request.user
         if form.is_valid():
             try:
+                logger.info("Received photo submission.")
                 mailing_list = MailingList.objects.get(
                     mailing_list_token="operation-pieton")
                 user = request.user
                 subscribe_user_to_list(user, mailing_list)
+                logger.info(f"Subscribed user {user} to list {mailing_list}.")
             except ObjectDoesNotExist:
-                logger.info("Mailing list operation-pieton does not exist")
+                logger.error("Mailing list operation-pieton does not exist")
 
             return self.form_valid(form)
         else:


### PR DESCRIPTION
Successful photo uploads were silent, we had no trace in the logs.
Failed photo uploads logged an info message and not an error.

This commit fixes those two issues.