### PR TITLE
Add more search filters and reorder Admin display

### DIFF
--- a/transport_nantes/utm/admin.py
+++ b/transport_nantes/utm/admin.py
@@ -2,8 +2,11 @@ from django.contrib import admin
 
 from .models import UTM
 
+
 class UtmAdmin(admin.ModelAdmin):
-    list_display = ('base_url', 'source', 'campaign', 'content')
-    search_fields = ('source', 'campaign', 'content')
+    list_display = ('session_id', 'timestamp', 'ua_is_bot',
+                    'source', 'campaign', 'content', 'base_url')
+    search_fields = ('source', 'campaign', 'content', 'base_url', 'session_id')
+
 
 admin.site.register(UTM, UtmAdmin)


### PR DESCRIPTION
The base url is too big to let us see the rest of fields, moved it
to right.
Can track user journey through the site easier now with session id
being searchable and timestamps displayed