### PR TITLE
Fix Send Record class in Login mails

### DIFF
--- a/transport_nantes/authentication/tests_auth.py
+++ b/transport_nantes/authentication/tests_auth.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.core import mail
 from django.test import TestCase, TransactionTestCase
 import datetime
 
@@ -65,6 +66,8 @@ class LoginViewTest(TransactionTestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
 
         # POST non-existing user
         response = self.client.post(
@@ -78,6 +81,9 @@ class LoginViewTest(TransactionTestCase):
         )
         # Expected to 200, displays an "Email sent" page.
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[1].to, [User.objects.get(
+            email="doesntexist@null.com").email])
 
         # POST existing user with password login
         response = self.client.post(
@@ -89,6 +95,11 @@ class LoginViewTest(TransactionTestCase):
                 "captcha_1": "PASSED",
             }
         )
+
+        # User with a password login are redirected to a password page and
+        # aren't sent a mail
+        self.assertEqual(len(mail.outbox), 2)
+
         # print("Response :", response)
         # Expected to redirect to password login page.
         # Printing the response shows it is a redirect to

--- a/transport_nantes/authentication/views.py
+++ b/transport_nantes/authentication/views.py
@@ -20,7 +20,7 @@ from django.views.generic.base import TemplateView
 from authentication.forms import (EmailLoginForm, PasswordLoginForm,
                                   UserUpdateForm, ProfileUpdateForm)
 from asso_tn.utils import make_timed_token, token_valid
-from topicblog.models import SendRecordTransactional
+from topicblog.models import SendRecordTransactional, SendRecordTransactionalAdHoc
 
 """
 A quick note on the captcha:
@@ -152,20 +152,20 @@ def send_activation(request, email, remember_me):
         send_record.save()
 
 
-def create_send_record(email: str) -> SendRecordTransactional:
-    """Create a SendRecordTransactional for the given email."""
+def create_send_record(email: str) -> SendRecordTransactionalAdHoc:
+    """Create a SendRecordTransactionalAdHoc for the given email."""
     try:
         recipient = User.objects.get(email=email)
     except User.DoesNotExist:
         logger.info("No user for email {}".format(email))
         recipient = None
-    send_record = SendRecordTransactional.objects.create(
+    send_record = SendRecordTransactionalAdHoc.objects.create(
         recipient=recipient)
     return send_record
 
 
 def prepare_email(email: str, request: HttpRequest,
-                  send_record: SendRecordTransactional) \
+                  send_record: SendRecordTransactionalAdHoc) \
         -> EmailMultiAlternatives:
     """Create a sendable Email object"""
     template = 'authentication/account_activation_email.html'


### PR DESCRIPTION
Wrong send record class was used, referred to SendRecordTransactional instead of SendRecordTransactionalAdHoc. 
