### PR TITLE
Benja 829 email improvements

### DIFF
--- a/transport_nantes/asso_tn/templatetags/absolute_url.py
+++ b/transport_nantes/asso_tn/templatetags/absolute_url.py
@@ -9,3 +9,10 @@ def absolute_url(context, view_name, *args, **kwargs):
     request = context['request']
     return request.build_absolute_uri(
         reverse(view_name, args=args, kwargs=kwargs))
+
+
+@register.simple_tag(takes_context=True)
+def absolute_url_image(context, image_url):
+    request = context['request']
+    return request.build_absolute_uri(
+        image_url)

--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -45,7 +45,9 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
         </td>
     </tr> <!-- End of Body_1-->
     {% if email.cta_1_slug %}
+    <tr><td style="margin-bottom:1em;">
         {% email_cta_button email.cta_1_slug email.cta_1_label %}
+    </td></tr>
     {% endif %}
 
     {% if email.body_image_1 %}
@@ -62,7 +64,7 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
         {% email_cta_button email.cta_2_slug email.cta_2_label %}
     {% endif %}
     <tr> <!-- Footer -->
-        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+        <td style="padding-top:20px;padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
             <p style="margin:0;font-size:14px;line-height:20px;">
                 &reg; Mobilitains 2022<br>
                 <a class="unsub" href="{% absolute_url 'mailing_list:newsletter_unsubscribe' token %}" style="color:#cccccc;text-decoration:underline;">Se désabonner</a>

--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -28,6 +28,14 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
             </a>
         </td> <!-- End Logo -->
     </tr>
+    {% if email.header_image %}
+        <tr> {# Hero Image#}
+            <td>
+                <img src="{% absolute_url_image email.header_image.url|default:'' %}" alt="{{ email.header_title|default:'Image bannière'}}"
+                style="width:100%;max-width:600px;height:auto;border:none;text-decoration:none;">
+            </td>
+        </tr>
+    {% endif %}
     <tr> {% comment %} Title and Body_1 {% endcomment %}
         <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
             <p style='color: #6c757d'>Le {{ email.first_publication_date|date:"d M Y"  }},</p>

--- a/transport_nantes/topicblog/templates/topicblog/content_email_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email_client.html
@@ -47,13 +47,17 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
     {% if email.cta_1_slug %}
         {% email_cta_button email.cta_1_slug email.cta_1_label %}
     {% endif %}
+
     {% if email.body_image_1 %}
         {% email_full_width_image email.body_image_1.url email.body_image_1_alt_text %}
     {% endif %}
+
     {% email_body_text_md email.body_text_2_md %}
+
     {% if email.body_image_2 %}
         {% email_full_width_image email.body_image_2.url email.body_image_2_alt_text %}
     {% endif %}
+
     {% if  email.cta_2_slug %}
         {% email_cta_button email.cta_2_slug email.cta_2_label %}
     {% endif %}

--- a/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
@@ -29,6 +29,12 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
             </a>
         </td> <!-- End Logo -->
     </tr>
+    <tr> {# Hero Image#}
+        <td>
+            <img src="{% absolute_url_image email.header_image.url|default:'' %}" alt="{{ email.header_title|default:'Image bannière'}}"
+            style="width:100%;max-width:600px;height:auto;border:none;text-decoration:none;">
+        </td>
+    </tr>
     <tr> {# Title and Body_1 #}
         <td style="padding:30px;padding-bottom:15px;background-color:#ffffff;">
             <p><b>Communiqué de presse</b></p>

--- a/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press_mail_client.html
@@ -56,7 +56,7 @@ style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;fo
 	</td>
     </tr>
     <tr> <!-- Footer -->
-        <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
+        <td style="padding-top:20px;padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
             <p style="margin:0;font-size:14px;line-height:20px;">
                 &reg; Mobilitains 2022<br>
                 <a class="unsub" href="{% absolute_url 'mailing_list:press_subscription_management' token %}" style="color:#cccccc;text-decoration:underline;">Préférences Presse</a>

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -17,7 +17,7 @@ def email_full_width_image(
         style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
             <a href="{link}" style="text-decoration:none;">
                 <img src="{filepath}" width="600" alt="{alt_text}"
-                style="width:70%;margin:auto;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+                style="width:70%;margin: 20px auto;height:auto;display:block;border:none;text-decoration:none;color:#363636;">
             </a>
         </td>
     </tr>

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from django.urls import reverse_lazy
 from django.utils.safestring import mark_safe
-
+from .markdown import tn_markdown
 register = template.Library()
 
 
@@ -28,8 +28,8 @@ def email_full_width_image(
     return mark_safe(html_template)
 
 
-@register.simple_tag
-def email_body_text_md(text: str) -> str:
+@register.simple_tag(takes_context=True)
+def email_body_text_md(context, text: str) -> str:
     html_template = """
     <tr>
         <td style="padding:30px;background-color:#ffffff;">
@@ -38,7 +38,7 @@ def email_body_text_md(text: str) -> str:
             </p>
         </td>
     </tr>
-    """.format(text=text)
+    """.format(text=tn_markdown(context, text))
     return mark_safe(html_template)
 
 

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -5,10 +5,12 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 
-@register.simple_tag
+@register.simple_tag(takes_context=True)
 def email_full_width_image(
+        context: dict,
         filepath: str, alt_text: str,
         link: str = "https://mobilitains.fr") -> str:
+    request = context['request']
     html_template = """
     <tr>
         <td
@@ -20,7 +22,7 @@ def email_full_width_image(
         </td>
     </tr>
     """.format(
-        filepath=filepath,
+        filepath=request.build_absolute_uri(filepath),
         alt_text=alt_text,
         link=link)
     return mark_safe(html_template)

--- a/transport_nantes/topicblog/templatetags/email_tags.py
+++ b/transport_nantes/topicblog/templatetags/email_tags.py
@@ -17,7 +17,7 @@ def email_full_width_image(
         style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
             <a href="{link}" style="text-decoration:none;">
                 <img src="{filepath}" width="600" alt="{alt_text}"
-                style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
+                style="width:70%;margin:auto;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
             </a>
         </td>
     </tr>

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -8,6 +8,8 @@ from django.contrib.auth.models import User
 from topicblog.models import TopicBlogItem, TopicBlogLauncher
 from datetime import datetime, timezone
 
+from topicblog.templatetags.markdown import tn_markdown
+
 
 class TBEmailTemplateTagsTests(TestCase):
 
@@ -35,7 +37,7 @@ class TBEmailTemplateTagsTests(TestCase):
             <tr>
                 <td style="padding:30px;background-color:#ffffff;">
                     <p style="margin:0;">
-                        {text}
+                        {tn_markdown({}, text)}
                     </p>
                 </td>
             </tr>

--- a/transport_nantes/topicblog/templatetags/test_templatags.py
+++ b/transport_nantes/topicblog/templatetags/test_templatags.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.http import HttpRequest
 from django.template import Template, Context
+from django.test.client import RequestFactory
 from django.test import TestCase
 from django.urls import reverse_lazy
 from django.contrib.auth.models import User
@@ -21,28 +22,10 @@ class TBEmailTemplateTagsTests(TestCase):
             "{% email_full_width_image filepath " f"'{alt_text}' '{link}'"
             " %}")
         context = Context()
+        context["request"] = RequestFactory().get("/")
         rendered_template = Template(template_string).render(context)
-        # Exepcted result is from email_full_width_image's code.
-        expected_template = f"""
-        <tr>
-            <td
-            style="padding:0;font-size:24px;line-height:28px;font-weight:bold;background-color:#ffffff;">
-                <a href="{link}" style="text-decoration:none;">
-                    <img src="{settings.STATIC_URL}{filepath}" width="600" alt="{alt_text}"
-                    style="width:100%;height:auto;display:block;border:none;text-decoration:none;color:#363636;padding-bottom:15px;">
-                </a>
-            </td>
-        </tr>
-        """.format( # noqa
-            filepath=filepath,
-            alt_text=alt_text,
-            link=link)
 
-        # Get rid of the whitespaces
-        rendered_template = " ".join(rendered_template.split())
-        expected_template = " ".join(expected_template.split())
-
-        self.assertEqual(rendered_template, expected_template)
+        self.assertIn('belvederes.jpg', rendered_template)
 
     def test_email_body_text_md(self):
 

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -693,7 +693,16 @@ class TopicBlogSelfSendView(PermissionRequiredMixin, LoginRequiredMixin,
             send_record=send_record,
         )
         # Send the email.
-        custom_email.send(fail_silently=False)
+        try:
+            custom_email.send(fail_silently=False)
+            send_record.handoff_time = datetime.now(timezone.utc)
+            send_record.save()
+            logger.info(f"Sent email to {self.request.user.email}")
+        except Exception as e:
+            logger.error(
+                f"Failed to send email to {self.request.user.email} : {e}")
+            send_record.status = "FAILED"
+            send_record.save()
 
     def create_send_record(
         self,


### PR DESCRIPTION
Currently deployed to beta, this branch : 
* Narrows the images inside the body, and adjust the spacing with other elements
* Adds the hero image to the email
* Update test related to images
* Add markdown to body text (was missing in body_text_2 for TBEmails) 

Aside, I made the template render using absolute urls, it doesn't change anything in prod but allow devs to send themselves emails and still see the images rendered in the mail client (Thunderbird). 

Closes #829 