### PR TITLE
Make inline tn_markdown context aware

### DIFF
--- a/transport_nantes/topicblog/templates/topicblog/content.html
+++ b/transport_nantes/topicblog/templates/topicblog/content.html
@@ -88,7 +88,7 @@
                <a href="{% url 'topic_blog:view_item_by_slug' page.cta_1_slug %}" 
 		  class="btn donation-button my-3 centered-inline-button">
 		   {{ page.cta_1_label }}
-		   <i class="fa fa-arrow-right"" aria-hidden="true"></i>
+		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
 	       </a>
           {% endif %}
 
@@ -99,7 +99,7 @@
                <a href="{% url 'topic_blog:view_item_by_slug' page.cta_2_slug %}" 
                class="btn donation-button my-3 centered-inline-button">
 		   {{ page.cta_2_label }}
-		   <i class="fa fa-arrow-right"" aria-hidden="true"></i>
+		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
 	       </a>
           {% endif %}
 

--- a/transport_nantes/topicblog/tn_links.py
+++ b/transport_nantes/topicblog/tn_links.py
@@ -190,9 +190,9 @@ class TNLinkParser(object):
         """
         if 'don' == self.bracket_class_string:
             if '' == self.bracket_label_string:
-                self.out_string += don.bouton_don(self.paren_string)
+                self.out_string += don.bouton_don(self.paren_string, context=self.context)
             elif 'large' == self.bracket_label_string:
-                self.out_string += don.bouton_don_lg(self.paren_string)
+                self.out_string += don.bouton_don_lg(self.paren_string, context=self.context)
             elif 'adhésion' == self.bracket_label_string:
                 self.out_string += don.bouton_join(self.paren_string)
             elif self.bracket_label_string.startswith('fixed|'):
@@ -225,7 +225,7 @@ class TNLinkParser(object):
                 url = reverse('topic_blog:view_item_by_slug', args=[self.paren_string])
             except NoReverseMatch:
                 url = '(((pas trouvé : {ps})))'.format(ps=self.paren_string)
-            self.out_string += don.action_button(url, self.bracket_label_string)
+            self.out_string += don.action_button(url, self.bracket_label_string, context=self.context)
         elif 'slug' == self.bracket_class_string:
             self.out_string += slug.tbi_slug(self.context,
                                              self.bracket_label_string,
@@ -237,7 +237,7 @@ class TNLinkParser(object):
             self.out_string += don.external_url(url, self.bracket_label_string)
         elif 'EXTERNE' == self.bracket_class_string:
             url = self.paren_string
-            self.out_string += don.external_url_button(url, self.bracket_label_string)
+            self.out_string += don.external_url_button(url, self.bracket_label_string, context=self.context)
         elif 'petition' == self.bracket_class_string:
             self.out_string += newsletter.petition_link(self.paren_string, self.bracket_label_string)
         else:


### PR DESCRIPTION
This allows us to know if we're rendering for web or email.
Email don't accept css classes, and require hardcoded styles.

Part of #840