### PR TITLE
Update PressMention

### DIFF
--- a/transport_nantes/press/models.py
+++ b/transport_nantes/press/models.py
@@ -16,13 +16,12 @@ class PressMention(models.Model):
     article_title = models.CharField(max_length=200)
     article_summary = models.TextField()
     article_publication_date = models.DateField()
-    # OG data SHOULD NOT be blank, but if the site
-    # can't provide open graph or the user gives the wrong
-    # article link we let the possibility of the data to be blank.
+
+    # Not all sites have opengraph data.
     og_title = models.CharField(max_length=255, blank=True)
     og_description = models.TextField(blank=True)
     og_image = models.ImageField(
-        upload_to="press_mention/open_graph/", blank=True, default="press_mention/open_graph/default_press_mention.jpg")
+        upload_to="press_mention/open_graph/", blank=True, null=True)
 
     def __str__(self):
         return f"{self.newspaper_name} {self.article_title}"

--- a/transport_nantes/press/templates/press/press_detail.html
+++ b/transport_nantes/press/templates/press/press_detail.html
@@ -16,12 +16,9 @@
                     {% if  object.og_image %}
                     <img src="{{ object.og_image.url }}" style="object-fit: cover;width: 100%;height: 250px;"
                     class="card-img" alt="{{ object.newspaper_name }}">
-                    {% else %}
-                        {% comment %}
-                        SHOULD NOT happen but if the website doesn't have
-                        open graph image we don't display the image
-                        {% endcomment %}
-                        <p>Pas d'image</p>
+                    {% else %} {% comment %} If no open graph image we
+                        display no image. {% endcomment %}
+                        <p>&nbsp;</p>
                     {% endif %}
                 </div>
                 <div class="col-md-8">
@@ -38,12 +35,9 @@
         <div class="card mb-3 p-0 col-12 col-md-6">
             {% if  object.og_image %}
             <img src="{{ object.og_image.url }}" class="card-img" alt="{{ object.newspaper_name }}">
-            {% else %}
-                {% comment %}
-                SHOULD NOT happen but if the website doesn't have
-                open graph image we don't display the image
-                {% endcomment %}
-                <p>Pas d'image</p>
+            {% else %} {% comment %}If no open graph image we display
+                no image. {% endcomment %}
+                <p>&nbsp;</p>
             {% endif %}
             <div class="card-body">
                 <a href="{{ object.article_link }}" class="stretched-link text-muted text-decoration-none font-weight-bold">{{ object.get_domaine_of_link }}</a>

--- a/transport_nantes/press/templates/press/press_list_view.html
+++ b/transport_nantes/press/templates/press/press_list_view.html
@@ -6,12 +6,9 @@
         <div class="card mb-3 p-0 h-100">
           {% if  press_mention.og_image %}
           <img src="{{ press_mention.og_image.url }}" class="card-img" alt="{{ press_mention.newspaper_name }}" style="height: 150px;">
-          {% else %}
-              {% comment %}
-              SHOULD NOT happen but if the website doesn't have
-              open graph image we don't display the image
-              {% endcomment %}
-              <p>Pas d'image</p>
+          {% else %} {% comment %}If no open graph image we display no
+              image.  {% endcomment %}
+              <p>&nbsp;</p>
           {% endif %}
           <div class="card-body">
               <a href="{{ press_mention.article_link }}" class="stretched-link text-muted text-decoration-none font-weight-bold">{{ press_mention.get_domaine_of_link }}</a>

--- a/transport_nantes/press/templates/press/table_list.html
+++ b/transport_nantes/press/templates/press/table_list.html
@@ -31,12 +31,9 @@
         <td>
           {% if  press_mention.og_image %}
             <img src="{{ press_mention.og_image.url }}" alt="{{ press_mention.article_title }}" style="width:200px;max-height: 200px;">
-          {% else %}
-          {% comment %}
-            SHOULD NOT happen but if the website doesn't have
-            open graph image we don't display the image
-          {% endcomment %}
-            <p>Pas d'image</p>
+          {% else %} {% comment %} If no open graph image we display
+          no image.  {% endcomment %}
+            <p>&nbsp;</p>
           {% endif %}
         <td>{{ press_mention.article_publication_date|date:"d/m/Y" }}</td>
         <td>
@@ -60,12 +57,9 @@
     <div>
       {% if  press_mention.og_image %}
         <img src="{{ press_mention.og_image.url }}" alt="{{ press_mention.article_title }}" style="width:200px;max-height: 200px;">
-      {% else %}
-      {% comment %}
-        SHOULD NOT happen but if the website doesn't have
-        open graph image we don't display the image
-      {% endcomment %}
-        <p>Pas d'image</p>
+      {% else %} {% comment %} If no open graph image we display no
+      image.  {% endcomment %}
+        <p>&nbsp;</p>
       {% endif %}
     </div>
     <div class="d-flex justify-content-around">

--- a/transport_nantes/press/urls.py
+++ b/transport_nantes/press/urls.py
@@ -7,9 +7,13 @@ app_name = 'press'
 
 urlpatterns = [
     path('', PressMentionListView.as_view(), name='view'),
-    path('list/', PressMentionListViewAdmin.as_view(), name='list_items'),
-    path('new/', PressMentionCreateView.as_view(), name='new_item'),
-    path('update/<int:pk>', PressMentionUpdateView.as_view(), name='update_item'),
-    path('delete/<int:pk>', PressMentionDeleteView.as_view(), name='delete_item'),
-    path('detail/<int:pk>', PressMentionDetailView.as_view(), name='detail_item'),
+    path('admin/list/', PressMentionListViewAdmin.as_view(),
+         name='list_items'),
+    path('admin/new/', PressMentionCreateView.as_view(), name='new_item'),
+    path('admin/update/<int:pk>', PressMentionUpdateView.as_view(),
+         name='update_item'),
+    path('admin/delete/<int:pk>', PressMentionDeleteView.as_view(),
+         name='delete_item'),
+    path('admin/detail/<int:pk>', PressMentionDetailView.as_view(),
+         name='detail_item'),
 ]

--- a/transport_nantes/press/views.py
+++ b/transport_nantes/press/views.py
@@ -162,7 +162,9 @@ def fetching_open_graph_data(form=False, presmention_id=None):
     try:
         page = requests.get(url)
     except Exception as e:
-        logger.warning(f"Can't acess to the website {e}.")
+        # It would be better to log the status code rather than a
+        # semi-meaningless "can't access".
+        logger.warning(f"Can't acess {e}.")
         return None
     tree = html.fromstring(page.content.decode("utf-8"))
     og_title = tree.xpath('//meta[@property="og:title"]/@content')
@@ -170,7 +172,7 @@ def fetching_open_graph_data(form=False, presmention_id=None):
         '//meta[@property="og:description"]/@content')
     og_image = tree.xpath('//meta[@property="og:image"]/@content')
     if not og_title or not og_description:
-        logger.warning("This website doesn't have all open graph data.")
+        logger.info(f"No opengraph data at {url}.")
         return None
     else:
         if form:


### PR DESCRIPTION
* Label admin views as such.
* Drop uploading a fresh copy of a default view with every article
  missing opengraph data.  (It's wasteful for the server, confusing
  for the user.)
* If we've no image to show, show no image.  Show a non-breaking space
  instead just to avoid some browser shortcutting.
* Update a few comments.

Part of #867.