### PR TITLE
Switch color patterns to stick to style guidelines

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/css/recording.css
+++ b/transport_nantes/mobilito/static/mobilito/css/recording.css
@@ -1,4 +1,3 @@
-/* Why is root being redefined/extended? */
 :root {
     --button-color: var(--mobilitains-bleu);
     --button-font-color: #fff;
@@ -19,11 +18,7 @@ body {
     justify-content: center;
     font-size: 46px;
     color: var(--button-font-color);
-    transition: background-color 0.2s ease-out;
     margin: 0.10rem;
-}
-.mobilito-btn:active {
-    filter: brightness(1.3);
 }
 .mobilito-btn:focus {
     outline: none;
@@ -54,15 +49,31 @@ button[data-field="pedestrian"] {
     background-color: var(--mobilitains-bleu);
     border-color: var(--mobilitains-bleu);
 }
+.pedestrian:active {
+    background-color: white;;
+    color: var(--mobilitains-bleu);
+}
 button[data-field="bicycle"] {
     background-color: var(--mobilitains-bleu-marine);
     border-color: var(--mobilitains-bleu-marine);
+}
+.bicycle:active {
+    background-color: white;;
+    color: var(--mobilitains-bleu-marine);
 }
 button[data-field="motor-vehicle"] {
     background-color: var(--mobilitains-orange);
     border-color: var(--mobilitains-orange);
 }
+.motor-vehicle:active {
+    background-color: white;;
+    color: var(--mobilitains-orange);
+}
 button[data-field="public-transport"] {
     background-color: var(--mobilitains-rouge);
     border-color: var(--mobilitains-rouge);
+}
+.public-transport:active {
+    background-color: white;;
+    color: var(--mobilitains-rouge);
 }

--- a/transport_nantes/mobilito/templates/mobilito/recording.html
+++ b/transport_nantes/mobilito/templates/mobilito/recording.html
@@ -31,7 +31,7 @@ method="post" action="{% url 'mobilito:recording' %}"> {% csrf_token %}
                 <button type="button"
                 data-quantity="plus"
                 data-field="pedestrian"
-                class='mobilito-btn d-flex flex-column p-5'>
+                class='mobilito-btn d-flex flex-column p-5 pedestrian'>
                     <i class="fa fa-solid fa-person-walking"></i>
                     <span class="button-counter" name="pedestrian-counter">0</span>
                 </button>
@@ -48,7 +48,7 @@ method="post" action="{% url 'mobilito:recording' %}"> {% csrf_token %}
                 <button type="button"
                 data-quantity="plus"
                 data-field="bicycle"
-                class='mobilito-btn d-flex flex-column p-5'>
+                class='mobilito-btn d-flex flex-column p-5 bicycle'>
                     <i class="fa-solid fa-person-biking"></i>
                     <span class="button-counter" name="bicycle-counter">0</span>
                 </button>
@@ -67,7 +67,7 @@ method="post" action="{% url 'mobilito:recording' %}"> {% csrf_token %}
                 <button type="button"
                 data-quantity="plus"
                 data-field="motor-vehicle"
-                class='mobilito-btn d-flex flex-column p-5'>
+                class='mobilito-btn d-flex flex-column p-5 motor-vehicle'>
                     <i class="fa-solid fa-car"></i>
                     <span class="button-counter" name="motor-vehicle-counter">0</span>
                 </button>
@@ -85,7 +85,7 @@ method="post" action="{% url 'mobilito:recording' %}"> {% csrf_token %}
                 type="button"
                 data-quantity="plus"
                 data-field="public-transport"
-                class='mobilito-btn d-flex flex-column p-5'>
+                class='mobilito-btn d-flex flex-column p-5 public-transport'>
                     <i class="fa-solid fa-train-tram"></i>
                     <span class="button-counter" name="public-transport-counter">0</span>
                 </button>


### PR DESCRIPTION
Buttons now behave like the other buttons on the website.
We turn background to white and turn whatever color was in background
as the font color.

Closes #875