### PR TITLE
Prevent refresh on overscroll in recording page

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/css/recording.css
+++ b/transport_nantes/mobilito/static/mobilito/css/recording.css
@@ -6,6 +6,7 @@
 body {
     display: flex;
     flex-direction: column;
+    overscroll-behavior: contain;
 }
 .mobilito-btn {
     background-color: var(--button-color);


### PR DESCRIPTION
According to this
https://usefulangle.com/post/278/html-disable-pull-to-refresh-with-css
this property should prevent the refresh to happen when the user is
scrolling the page.

closes #891