### PR TITLE
Allow user to select on position on map without locating themselves

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/css/geolocation_form.css
+++ b/transport_nantes/mobilito/static/mobilito/css/geolocation_form.css
@@ -12,7 +12,6 @@ footer {
     display: none;
 }
 #map {
-    display: none;
     margin-bottom: 1em;
     height: 300px;
     width: 100%;

--- a/transport_nantes/mobilito/static/mobilito/css/geolocation_form.css
+++ b/transport_nantes/mobilito/static/mobilito/css/geolocation_form.css
@@ -18,3 +18,7 @@ footer {
     border: 1px solid black;
     color: black;
 }
+div.leaflet-control-locate > a > span {
+    font-size: large;
+    vertical-align: middle;
+}

--- a/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
+++ b/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
@@ -21,7 +21,15 @@ const LOCATE_OPTIONS = {
             return `<p>Vous êtes dans les ${distance} ${unit} de ce point.</p>`
         },
         metersUnit: "mètres"
-    }
+    },
+    setView: false,
+    clickBehavior: {
+        inView: 'stop',
+        outOfView: 'stop',
+        inViewNotFollowing: 'stop'
+    },
+    icon: 'fa-solid fa-location-crosshairs'
+
 }
 L.control.locate(LOCATE_OPTIONS).addTo(map);
 var marker;
@@ -71,6 +79,15 @@ map.on('locationfound', onLocationFound);
 var isLoading = false;
 // What happens when user clicks on the map.
 function onMapClick(e) {
+    // If position location is toggled ON and user clicks on the map, we
+    // toggle off the control. A way to see if the location is toggled on is
+    // to check if the div with the class 'leaflet-control-locate' has the
+    // class 'active'.
+    if ($('.leaflet-control-locate').hasClass('active')) {
+        // The <a> element inside the control effectively toggles the control
+        // on/off.
+        $('a.leaflet-bar-part')[0].click();
+    }
     // If the user is already loading, don't do anything.
     if (isLoading) {
         return;

--- a/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
+++ b/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
@@ -8,7 +8,7 @@ https://developers.google.com/maps/documentation/geocoding/requests-reverse-geoc
 */
 
 // Initializing the map
-var map = L.map('map').fitWorld();
+var map = L.map('map').setView([47.218371, -1.553621], 8);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
@@ -55,13 +55,6 @@ $('#share-location').on('click', function () {
 // What happens when user has granted permission to share location and it's
 // been found.
 function onLocationFound(e) {
-    // Display the map with the user's location.
-    $('#map').css('display', 'block');
-    // Display None prevents the map from knowing its size, calling
-    // invalidateSize() once the map has an actual size fixes a bug where the
-    // map doesn't display properly. (Apparently, it doesn't know how many
-    // tiles it has to load)
-    map.invalidateSize();
     // setView centers the map on the user's location, whith a zoom level that
     // depends on the event's accuracy. (More accurate = zoom level higher)
     // https://leafletjs.com/examples/zoom-levels/

--- a/transport_nantes/mobilito/templates/mobilito/geolocation_form.html
+++ b/transport_nantes/mobilito/templates/mobilito/geolocation_form.html
@@ -44,10 +44,6 @@
 
 <section id="address-form" class="container">
     <p>Ce serait pratique de connaître l'adresse que vous observez :</p>
-    <button id="share-location" type="button"
-    class="d-flex btn donation-button mb-5 mx-auto">
-        Je me localise
-    </button>
 
     <div id="map"></div>
 


### PR DESCRIPTION
We used to ask for location permission when the user clicked on the "Je partage ma position" button. This was not ideal because the user couldn't use the map to set their location without giving us permission to track them.

The map is now centered on Nantes unzoomed by default, and user is now only located once they click the control button to locate themselves on the map.