### PR TITLE
Move next page arrow to the right on top of tutorial pages

### DIFF
--- a/transport_nantes/mobilito/templates/mobilito/tutorial.html
+++ b/transport_nantes/mobilito/templates/mobilito/tutorial.html
@@ -9,6 +9,7 @@
 {% block app_content %}
 <div class="container">
     <section id="tutorial" class="mt-3">
+        <div class="d-flex justify-content-between">
         <ul class="nav nav-pills mb-1">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">Sommaire</a>
@@ -26,15 +27,19 @@
               </div>
             </li>
         </ul>
+            {% if not seen_all_pages %}
+                {% include 'mobilito/next_page_arrow.html' with next_page=the_next_page %}
+            {% endif %}
+        </div>
         {% block tutorial_content %}{% endblock tutorial_content %}
         {% if seen_all_pages %}
             <div style="text-align: center">
-            <a href="{% url 'mobilito:address_form'%}" class="btn donation-button mx-auto" style="border-radius:5px;">
-                Passer à l'enregistrement >>
-            </a>
+                <a href="{% url 'mobilito:address_form'%}"
+                class="btn donation-button mx-auto"
+                style="border-radius:5px;">
+                    Passer à l'enregistrement >>
+                </a>
             </div>
-        {% else %}
-            {% include 'mobilito/next_page_arrow.html' with next_page=the_next_page %}
         {% endif %}
     </section>
 </div>


### PR DESCRIPTION
This avoids jumpings in arrow position.

![image](https://user-images.githubusercontent.com/70256364/192782225-8d5e3a3f-29a7-460a-90a0-24e45408b825.png)
