### PR TITLE
Improve navbar's hamburger responsive

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -410,9 +410,6 @@ span.centered {
     opacity:0.9;
   }
 @media (min-width: 992px) {
-    .navbar-logo {
-        max-width: 18%;
-    }
     .navbar-logo-image {
         width: 100% !important;
         height: 100%;
@@ -585,4 +582,21 @@ span.centered {
     width: 100%;
     height: 20vh;
     object-fit: cover;
+}
+.nav-item {
+    white-space: nowrap;
+}
+.logo-menu-holder {
+    width: 100%;
+}
+@media screen and (min-width: 768px) {
+    .logo-menu-holder {
+        width: auto;
+    }
+}
+#nosProjetsDropdown + .dropdown-menu > a {
+    color: #fff;
+}
+#nosProjetsDropdown {
+    color: #fff;
 }

--- a/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
@@ -163,17 +163,32 @@
 	    {% endif %}
 		{% block body %}
 			{% block navbar %}
-				<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-					<!-- Brand -->
-					<a class="navbar-brand navbar-logo" href="{% url 'index' %}"><img class="navbar-logo-image" src="{% static 'asso_tn/M-logo_white-32.png' %}" alt="Mobilitains logo"></a>
-					<!-- Toggler/collapsibe Button -->
-					<button class="navbar-toggler" data-toggle="collapse" data-target=".navbars">
-						<span class="navbar-toggler-icon"></span>
-					</button>
+				<nav class="navbar navbar-expand-xl navbar-dark bg-dark">
+					<div class="d-flex logo-menu-holder">
+						<!-- Brand -->
+						<a class="navbar-brand navbar-logo" href="{% url 'index' %}">
+							<img class="navbar-logo-image mr-3 ml-lg-0" style="max-width:100%;" src="{% static 'asso_tn/M-logo_white-32.png' %}" alt="Mobilitains logo">
+						</a>
+						<!-- Toggler/collapsibe Button -->
+						<button class="navbar-toggler d-md-none ml-auto mr-2" data-toggle="collapse" data-target=".navbars">
+							<span class="navbar-toggler-icon  my-auto ml-1"></span>
+						</button>
+						{# Donate button outside of Hamburger Menu #}
+						<div class="d-none d-sm-flex d-md-none">
+							<ul class="navbar-nav ml-auto my-auto">
+								<li class="nav-item">
+									{% bouton_don "CONTRIBUER AU PROJET" %}
+								</li>
+							</ul>
+						</div>
+					</div>
 
 					<!-- NavLink Menu -->
 					<div class="collapse navbar-collapse navbars" id="collapse_target1">
 						<ul class="navbar-nav ml-auto">
+							<li class="nav-item">
+								<a class="nav-link pr-4" href="{% url 'topic_blog:view_item_by_slug' 'la-petite-mobilite' %}">La Petite Mobilité</a>
+							</li>
 							<li class="nav-item">
 								<a class="nav-link pr-4" href="{% url 'topic_blog:view_item_by_slug' 'velopolitain' %}">Vélopolitain</a>
 							</li>
@@ -183,8 +198,37 @@
 							<li class="nav-item">
 								<a class="nav-link pr-5" href="{% url 'topic_blog:view_item_by_slug' 'qui-sommes-nous' %}">Qui sommes-nous ?</a>
 							</li>
+							<div class="d-block d-md-none">
+								<li class="nav-item">
+									{% bouton_don "CONTRIBUER AU PROJET" %}
+								</li>
+							</div>
+						</ul>
+					</div>
 
-							<li class="nav-item">{% bouton_don "CONTRIBUER AU PROJET" %}</li>
+					{# Nos projets dropdown #}
+					<div class="dropdown show d-none d-md-flex d-xl-none ml-auto mr-2">
+						<a class="btn bg-dark dropdown-toggle"
+						href="#" role="button" id="nosProjetsDropdown"
+						data-toggle="dropdown" aria-haspopup="true"
+						aria-expanded="false">
+						  Nos Projets
+						</a>
+
+						<div class="dropdown-menu bg-dark" aria-labelledby="nosProjetsDropdown">
+						  <a class="dropdown-item" href="{% url 'topic_blog:view_item_by_slug' 'la-petite-mobilite' %}">La Petite Mobilité</a>
+						  <a class="dropdown-item" href="{% url 'topic_blog:view_item_by_slug' 'velopolitain' %}">Vélopolitain</a>
+						  <a class="dropdown-item" href="{% url 'topic_blog:view_item_by_slug' 'la-grande-mobilite' %}">La Grande Mobilité</a>
+						  <a class="dropdown-item" href="{% url 'topic_blog:view_item_by_slug' 'qui-sommes-nous' %}">Qui sommes-nous ?</a>
+						</div>
+					</div>
+
+					{# Donate button outside of Hamburger Menu #}
+					<div class="d-none d-md-block">
+						<ul class="navbar-nav ml-auto">
+							<li class="nav-item">
+								{% bouton_don "CONTRIBUER AU PROJET" %}
+							</li>
 						</ul>
 					</div>
 				</nav>


### PR DESCRIPTION
The navbar progressively displays fewer elements instead of hiding
everything under a hamburger menu at 992px.

Because of the addition of a new link, the links are moved to a
dropdown menu "Nos projets" at 1200px, then to a hamburger at 768px.

The donation button is always present on width > 576px, and is moved
to the hamburger menu below.