### PR TITLE
Secure MAPS API key and transfer the API call to server

### DIFF
--- a/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
+++ b/transport_nantes/asso_tn/templates/asso_tn/base_mobilitain.html
@@ -95,6 +95,25 @@
 					<noscript><p><img src="//wa.mobilitains.fr/matomo.php?idsite=3&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 					<!-- End Matomo Code -->
 					{% endif %}
+					<script type="text/javascript">
+						// From django docs
+						// https://docs.djangoproject.com/en/dev/howto/csrf/#s-acquiring-csrf-token-from-cookie
+						function getCookie(name) {
+							let cookieValue = null;
+							if (document.cookie && document.cookie !== '') {
+								const cookies = document.cookie.split(';');
+								for (let i = 0; i < cookies.length; i++) {
+									const cookie = cookies[i].trim();
+									// Does this cookie string begin with the name we want?
+									if (cookie.substring(0, name.length + 1) === (name + '=')) {
+										cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+										break;
+									}
+								}
+							}
+							return cookieValue;
+						}
+					</script>
 				{% endcompress %}
 
 

--- a/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
+++ b/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
@@ -112,15 +112,17 @@ map.on('click', onMapClick);
 
 // Function to get user's location with geocoding, limited 50 requests per second.
 async function getGeocodedAddress(lat, lng) {
-    let api_key = JSON.parse(document.getElementById('maps_api_key').textContent);
-    let url = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${api_key}`;
+    let url = "/mobilito/ajax/get-address/";
     let response = await $.ajax({
         url: url,
-        type: 'GET',
+        headers: {"X-CSRFToken": getCookie("csrftoken")},
+        type: 'POST',
         dataType: 'json',
-        success: function (data) {
-            console.log(data);
+        data: {
+            lat: lat,
+            lng: lng,
         },
+        mode: 'same-origin',
         error: function (err) {
             console.log(err);
         }

--- a/transport_nantes/mobilito/static/mobilito/js/plus_minus_buttons.js
+++ b/transport_nantes/mobilito/static/mobilito/js/plus_minus_buttons.js
@@ -1,19 +1,3 @@
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
-
 $(document).ready(function(){
 
     var last_event = '';

--- a/transport_nantes/mobilito/templates/mobilito/geolocation_form.html
+++ b/transport_nantes/mobilito/templates/mobilito/geolocation_form.html
@@ -13,7 +13,6 @@
     {# Leaflet JS locate control #}
     <link rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css" />
-    {{ MAPS_API_KEY|json_script:"maps_api_key" }}
     {# Leaflet JS geocoder control #}
     <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css" />
 

--- a/transport_nantes/mobilito/urls.py
+++ b/transport_nantes/mobilito/urls.py
@@ -16,4 +16,6 @@ urlpatterns = [
          name='session_summary'),
 
     path('ajax/create-event/', views.create_event, name='event_creation'),
+    path('ajax/get-address/', views.ReverseGeocodingView.as_view(),
+         name='geocoding'),
 ]

--- a/transport_nantes/press/static/press/js/refresh-og.js
+++ b/transport_nantes/press/static/press/js/refresh-og.js
@@ -1,20 +1,3 @@
-// From django docs
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
-
 const isValidUrl = urlString => {
     try { 
         return Boolean(new URL(urlString)); 


### PR DESCRIPTION
To avoid disclosing our API key and have a better control over the API calls, we now transfer the API call to our server. Clients make requests to our server, and if CSRF token is valid, the server makes the API call and returns the result to the client.

Closes #954