### PR TITLE
Refactor mobilito to avoid weird template view inheritance

### DIFF
--- a/transport_nantes/mobilito/tests.py
+++ b/transport_nantes/mobilito/tests.py
@@ -1,10 +1,38 @@
 from datetime import datetime, timezone
 
 from django.contrib.auth.models import User, Permission
-from django.test import TestCase, Client
+from django.test import TestCase, Client, RequestFactory
 from django.urls import reverse_lazy
+from http.cookies import SimpleCookie
 
 from .models import Session, MobilitoUser
+from .views import TutorialState, TutorialView
+
+
+class TutorialStateTests(TestCase):
+
+    def setUp(self):
+        self.tutorial_state = TutorialState()
+
+    def test_static_state(self):
+        self.assertEqual(self.tutorial_state.default_page(), "presentation")
+        self.assertEqual(self.tutorial_state.canonical_page("presentation"), "presentation")
+        self.assertEqual(self.tutorial_state.canonical_page("velos"), "velos")
+        self.assertEqual(self.tutorial_state.canonical_page("unknown"), "presentation")
+
+
+class TutorialViewTests(TestCase):
+
+    def setUp(self):
+        self.tutorial_state = TutorialState()
+
+    def test_state_progression(self):
+        client = Client()
+        response_1 = client.get("/mobilito/tutoriel/presentation/")
+        self.assertEqual(response_1.status_code, 200)
+        next_page = response_1.context["next_page"]
+        # A too-weak constraint.
+        self.assertTrue(next_page in self.tutorial_state.all_tutorial_pages)
 
 
 class SessionViewTests(TestCase):


### PR DESCRIPTION
Several mobilito template views were inheriting from a common template view class, which was really strange and difficult to understand.  It did this in order to share code that handled tracking which tutorials had been seen, which to view next, and when to save state for the user.  In doing that, it ended up requiring some slighly strange overrides to the standard get() / get_context_data() from the django library.  Brief, it was a bit twisted and not really a natural pattern for django.

This commit refactors the code responsible for tracking tutorial view state to a separate class, thus simplifying the view code.  In the process, refactor the view code to use the new tutorial state class.

Part of #966.