### PR TITLE
Redirect to session summary instead of thank you page

### DIFF
--- a/transport_nantes/mobilito/views.py
+++ b/transport_nantes/mobilito/views.py
@@ -296,7 +296,10 @@ class RecordingView(LoginRequiredMixin, TemplateView):
         request.session['number_of_public_transports'] = \
             number_of_public_transports
 
-        return HttpResponseRedirect(reverse('mobilito:thanks'))
+        return HttpResponseRedirect(
+            reverse('mobilito:mobilito_session_summary',
+                    kwargs={'session_sha1': mobilito_session.session_sha1})
+        )
 
 
 class ThankYouView(TemplateView):


### PR DESCRIPTION
Part of #993

The issue states that we need a button to make another session, and I agree on this but we have several PR pending on session summaries, I don't want this to be a merge nightmare so I'm postponing this change for later, it's not hard anyway.