### PR TITLE
Add temporary message to thank user for making a Mobilito session

### DIFF
--- a/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
+++ b/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
@@ -51,6 +51,16 @@
 
 {# Used to get the session's sha1 in Javascript #}
 {{ mobilito_session.session_sha1|json_script:'mobilito_session_sha1'}}
+    {% if messages %}
+        {% for message in messages %}
+        <div class="col-8 col-md-6 mx-auto alert alert-success alert-dismissible fade show" role="alert">
+            <span>{{ message }}</span>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+        {% endfor %}
+    {% endif %}
 <div class="container">
     <div class="d-flex flex-wrap col-12">
         

--- a/transport_nantes/mobilito/views.py
+++ b/transport_nantes/mobilito/views.py
@@ -18,6 +18,7 @@ from typing import Union
 from asso_tn.utils import make_timed_token, token_valid
 from authentication.views import create_send_record
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.mail import EmailMultiAlternatives
 from django.db.models import Q
@@ -300,19 +301,8 @@ class RecordingView(LoginRequiredMixin, TemplateView):
                 f"id={request.session.get('mobilito_session_id', '')}, "
                 f"user={request.user.email}, {e}")
 
-        # Thank you page
-        # request.session is used to fill the thank you page
-        request.session['recording_duration_minutes'] = int(
-            (
-                datetime.now(timezone.utc)
-                - mobilito_session.start_timestamp
-            ).total_seconds() // 60
-        )
-        request.session['number_of_pedestrians'] = number_of_pedestrians
-        request.session['number_of_bicycles'] = number_of_bicycles
-        request.session['number_of_cars'] = number_of_cars
-        request.session['number_of_public_transports'] = \
-            number_of_public_transports
+        messages.add_message(
+            request, messages.SUCCESS, 'Merci de votre participation !')
 
         return HttpResponseRedirect(
             reverse('mobilito:mobilito_session_summary',


### PR DESCRIPTION
The message framework allows us to push ephemeral messages to the users. Sharing the link or even reloading the page will remove the message.

![image](https://user-images.githubusercontent.com/70256364/204295963-8a63a222-10ff-44e6-a363-128039a4ccd2.png)


Part of #993