### PR TITLE
Benja create presse release index 1019

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ autopep8==1.5.7
 awscli==1.19.59
 backcall==0.1.0
 backports.zoneinfo==0.2.1
+beautifulsoup4==4.11.1
 billiard==3.6.4.0
 boto3==1.17.59
 botocore==1.20.59
@@ -116,6 +117,7 @@ selenium==4.1.0
 six==1.14.0
 sniffio==1.2.0
 sortedcontainers==2.4.0
+soupsieve==2.3.2.post1
 sqlparse==0.3.0
 stripe==2.55.0
 toml==0.10.2

--- a/transport_nantes/topicblog/models.py
+++ b/transport_nantes/topicblog/models.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timezone, timedelta
 import logging
+from typing import Union
 
+import bs4
+from bs4 import BeautifulSoup as bs
 from django.contrib.auth.models import User
 from django.forms import ValidationError
 from django.urls import reverse
 from django.db import models
 
 from mailing_list.models import MailingList
+
 
 logger = logging.getLogger("django")
 
@@ -438,7 +442,6 @@ class TopicBlogObjectSocialBase(TopicBlogObjectBase):
         help_text='Notes pour éditeurs : ne seront pas affichées sur le site',
         verbose_name="Notes libres pour éditeurs",
         blank=True, null=True)
-
 
     def set_social_context(self, context):
         """
@@ -1086,6 +1089,56 @@ class TopicBlogPress(TopicBlogObjectSocialBase):
     viewbypkid_object_url = 'topicblog:view_press_by_pkid'
     send_object_url = 'topicblog:send_press'
     description_of_object = 'Communiqué de presse'
+
+    # This is the value that defines the length of the first_paragraph property.
+    snippet_char_limit = 100
+
+    @property
+    def first_paragraph(self):
+        """Return the first paragraph of the body text.
+        """
+        from topicblog.templatetags.markdown import tn_markdown
+        rendered_text = tn_markdown({}, self.body_text_1_md)
+        soup = bs(rendered_text, 'html.parser')
+        # Finds the first "p" tag inside body_text_1_md.
+        first_paragraph = soup.find('p')
+        if first_paragraph:
+            # passed by reference
+            self.truncate_first_pragraph(first_paragraph)
+
+        return str(first_paragraph) or rendered_text[:self.snippet_char_limit] + '…'
+
+    def truncate_first_pragraph(
+            self,
+            element: Union[bs4.element.NavigableString, bs4.element.Tag],
+            total_length: int = 0):
+        """Trucnate the first paragraph from an element while preserving
+        the html tags.
+        The output is limited to 100 characters, not including the HTML
+        tags.
+        """
+        # NavigableString is a string inside a tag, like the text inside
+        # <p>text</p>. We can access the string with element.string.
+        # and we can replace it with element.string.replace_with().
+        if type(element) == bs4.element.NavigableString:
+            if total_length >= self.snippet_char_limit:
+                # When the cumulated length of the text is greater than
+                # self.snippet_char_limit, we remove the remaining text.
+                element.string.replace_with('')
+                return total_length
+            if total_length + len(str(element)) >= self.snippet_char_limit:
+                # When the cumulated length of the text is greater than
+                # self.snippet_char_limit, we truncate the text and add an ellipsis.
+                element.string.replace_with(
+                    str(element)[:self.snippet_char_limit - total_length] + '…')
+            return total_length + len(str(element))
+        else:
+            # We recursively inspect all children while counting the chars
+            # until we run out of children or reach self.snippet_char_limit chars.
+            for child in element.children:
+                total_length = self.truncate_first_pragraph(child, total_length)
+
+            return total_length
 
     def get_absolute_url(self):
         """Provide a link to view this object (by slug and id).

--- a/transport_nantes/topicblog/templates/topicblog/topicblogpress_index.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogpress_index.html
@@ -1,0 +1,64 @@
+{% extends 'asso_tn/base_mobilitain.html' %}
+{% load markdown %}
+
+{% block content %}
+
+    <div class="d-flex col-12 col-md-8 flex-column mx-auto my-3">
+        <h1 style="font-size:2rem;">Nos communiqués de presse</h1>
+        <hr>
+        <ol class="pl-0" style="list-style-type:none;">
+            {% for press_release in press_releases_list %}
+                <li class="no-gutters">
+                    <article class="d-flex col-12 flex-column">
+                        <a href="{% url press_release.viewbyslug_object_url press_release.slug %}">
+                            <h1 style="font-size:1.4em;">{{ press_release.title }}</h1>
+                        </a>
+                        <span><i>{{ press_release.publication_date|date:"l j F Y à G:i" }}</i></span>
+                        {% tn_markdown press_release.body_text_1_md|truncatechars:100 %}
+                    </article>
+                </li>
+                <hr>
+            {% endfor %}
+        </ol>
+    </div>
+
+
+    {% block pagination %}
+        <nav aria-label="pagination naviguation">
+            <ul class="pagination justify-content-center">
+                {% if page_obj.has_previous %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page=1"><i class="fas fa-angle-double-left"></i> Première</a>
+                    </li>
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Précédent</a>
+                    </li>
+                {% endif %}
+                {% for number in number_pagination_list %}
+                    {% if number == page_obj.number %}
+                    <li class="page-item active" aria-current="page">
+                        <a class="page-link active" href="#">{{ page_obj.number }}</a>
+                    </li>
+                    {% elif number in paginator.page_range %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ number }}">{{ number }}</a>
+                    </li>
+                    {% else %}
+                    <li class="page-item disabled">
+                        <a class="page-link" href="?page={{ number }}">{{ number }}</a>
+                    </li>
+                    {% endif %}
+                {% endfor %}
+                {% if page_obj.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Suivant</a>
+                    </li>
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Dernière <i class="fas fa-angle-double-right"></i></a>
+                    </li>
+                {% endif %}
+            </ul>
+        </nav>
+    {% endblock pagination %}
+
+{% endblock content %}

--- a/transport_nantes/topicblog/templates/topicblog/topicblogpress_index.html
+++ b/transport_nantes/topicblog/templates/topicblog/topicblogpress_index.html
@@ -14,11 +14,12 @@
                             <h1 style="font-size:1.4em;">{{ press_release.title }}</h1>
                         </a>
                         <span><i>{{ press_release.publication_date|date:"l j F Y à G:i" }}</i></span>
-                        {% tn_markdown press_release.body_text_1_md|truncatechars:100 %}
+                        {{ press_release.first_paragraph|safe }}
                     </article>
                 </li>
                 <hr>
             {% endfor %}
+            
         </ol>
     </div>
 

--- a/transport_nantes/topicblog/test_topic_blog_part_2.py
+++ b/transport_nantes/topicblog/test_topic_blog_part_2.py
@@ -878,6 +878,52 @@ class TBPTest(TestCase):
             self.assertEqual(response.status_code,
                              user_type["code"], msg=user_type["msg"])
 
+    def test_press_release_index(self):
+        now = datetime.now()
+        published_press_release = TopicBlogPress.objects.create(
+            title="Published Press Release",
+            slug="published-press-release",
+            body_text_1_md="This is the body",
+            publication_date=now,
+            user=self.staff,
+            template_name=self.template_press,
+        )
+        older_published_press_release = TopicBlogPress.objects.create(
+            title="Older Press Release",
+            slug="published-press-release",
+            body_text_1_md="This is the body",
+            publication_date=now - timedelta(days=1),
+            user=self.staff,
+            template_name=self.template_press,
+        )
+        published_press_release_with_different_slug = (
+            TopicBlogPress.objects.create(
+                title="Different Slug Press Release",
+                slug="published-press-release-with-different-slug",
+                body_text_1_md="This is the body",
+                publication_date=now,
+                user=self.staff,
+                template_name=self.template_press,
+            )
+        )
+        unpublished_press_release = TopicBlogPress.objects.create(
+            title="Unpublished Press Release",
+            slug="unpublished-press-release",
+            body_text_1_md="This is the body",
+            publication_date=None,
+            user=self.staff,
+            template_name=self.template_press,
+        )
+
+        url = reverse("topicblog:press_releases_index")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, published_press_release.title, count=1)
+        self.assertContains(
+            response, published_press_release_with_different_slug.title, count=1)
+        self.assertNotContains(response, unpublished_press_release.title)
+        self.assertNotContains(response, older_published_press_release.title)
+
 
 class TBLATest(TestCase):
     def setUp(self):

--- a/transport_nantes/topicblog/urls.py
+++ b/transport_nantes/topicblog/urls.py
@@ -73,6 +73,9 @@ topicblogemail_urls = [
          name='send_email'),
 ]
 topicblogpress_urls = [
+    path("communiques-de-presse/",
+         views.TopicBlogPressIndex.as_view(),
+         name="press_releases_index"),
     path('p/<slug:the_slug>/',
          views.TopicBlogPressView.as_view(),
          name='view_press_by_slug'),

--- a/transport_nantes/topicblog/views.py
+++ b/transport_nantes/topicblog/views.py
@@ -10,7 +10,7 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
 
-from django.db.models import Count, Max
+from django.db.models import Count, Max, Subquery, OuterRef, F
 from django.dispatch import receiver
 from django.http import (Http404, HttpResponseBadRequest,
                          HttpResponseServerError, FileResponse)
@@ -1080,8 +1080,31 @@ class TopicBlogPressSend(PermissionRequiredMixin, LoginRequiredMixin,
     success_url = "/"
 
 
+class TopicBlogPressIndex(ListView):
+    model = TopicBlogPress
+    template_name = 'topicblog/topicblogpress_index.html'
+    context_object_name = 'press_releases_list'
+    paginate_by = 10
+
+    def get_queryset(self) -> list:
+
+        # Subquery preparation
+        latest_press_release = TopicBlogPress.objects.filter(
+            slug=OuterRef('slug'),
+            publication_date__isnull=False).order_by('-publication_date')
+
+        queryset = TopicBlogPress.objects.annotate(
+            latest_press_release=Subquery(latest_press_release.values(
+                'publication_date')[:1])).filter(
+            publication_date=F('latest_press_release')).order_by(
+            '-publication_date')
+
+        return queryset
+
+
 ######################################################################
 # TopicBlogLauncher
+
 
 class TopicBlogLauncherViewOnePermissions(PermissionRequiredMixin):
     """Custom Permission class to require different permissions


### PR DESCRIPTION
This PR adds a view to list all published press released on a single page, in the same fashion @mcmikashi designed the press app. 
I reused his template, tweaked it a bit to fit topicblog and here it is. 

Deployed to beta, but as I'm not sure this will stay, here is a screenshot : 

![image](https://user-images.githubusercontent.com/70256364/204840326-a7fbd7b8-7715-4151-86ab-7960c60e5320.png)

(on the screenshot you see thrice the same image and nearly same title, they do have different slugs however, so this works !)

