### PR TITLE
Move flag session button under the address field in mobilito

### DIFF
--- a/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
+++ b/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
@@ -61,6 +61,40 @@
             <br/>
             <b><i class="fa-solid fa-crosshairs"></i> {{ mobilito_session.location }}</b>
         </p>
+        {# Dropdown menu #}
+        <div class="dropdown show col-12 mt-n3 mb-2">
+            <a href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="fa-solid fa-flag"></i>
+            </a>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+                <a class="dropdown-item" href="#"
+                {% if user_has_reported_this_session or request.user == mobilito_session.user.user %}
+                    style="pointer-events: none; color: grey;"
+                {% endif %}
+                >
+                    {% if request.user != mobilito_session.user.user %}
+                        {% if user_has_reported_this_session %}
+                            <span id="reported">
+                                Session signalée
+                            </span>
+                        {% else%}
+                            <span id="reported" class="d-none"
+                            style="color: grey;">
+                                Session signalée
+                            </span>
+                            <span id="report-abuse"
+                            data-toggle="modal" data-target="#report-abuse-div">
+                                Signaler
+                            </span>
+                        {% endif %}
+                    {% else %}
+                        <span>
+                            Signaler
+                        </span>
+                    {% endif %}
+                </a>
+            </div>
+        </div>
         
         {# Map, if location has lat/lng #}
         {% if mobilito_session.latitude and mobilito_session.longitude %}
@@ -95,40 +129,7 @@
         </div>
     </div>
 
-    {# Dropdown menu #}
-    <div class="dropdown show">
-        <a href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="fa-solid fa-ellipsis ml-md-3"></i>
-        </a>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
-            <a class="dropdown-item" href="#"
-            {% if user_has_reported_this_session or request.user == mobilito_session.user.user %}
-                style="pointer-events: none; color: grey;"
-            {% endif %}
-            >
-                {% if request.user != mobilito_session.user.user %}
-                    {% if user_has_reported_this_session %}
-                        <span id="reported">
-                            Session signalée
-                        </span>
-                    {% else%}
-                        <span id="reported" class="d-none"
-                        style="color: grey;">
-                            Session signalée
-                        </span>
-                        <span id="report-abuse"
-                        data-toggle="modal" data-target="#report-abuse-div">
-                            Signaler
-                        </span>
-                    {% endif %}
-                {% else %}
-                    <span>
-                        Signaler
-                    </span>
-                {% endif %}
-            </a>
-        </div>
-    </div>
+    
 
     {# Flag session modal #}
     {% if request.user != mobilito_session.user.user and not user_has_reported_this_session %}


### PR DESCRIPTION
The most likely reason someone might report a session is because of the free field that is user provided.
The color is dark enough so it doesn't scream click me, but you can still see if it if you look for it.
Part of #1027