### PR TITLE
Limit mobilito's session summary's map's height

### DIFF
--- a/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
+++ b/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
@@ -108,7 +108,7 @@
         
         {# Map, if location has lat/lng #}
         {% if mobilito_session.latitude and mobilito_session.longitude %}
-            <div id="map" class="col-10 col-md-8 col-lg-6 mx-auto"></div>
+            <div id="map" class="col-10 col-md-8 col-lg-6 mx-auto" style="max-height:23vh;"></div>
         {% endif %}
 
         {# Timeseries #}


### PR DESCRIPTION
The map was taking too much space especially on smaller devices. This commit limits the height to 23% of the screen's height.

It's a compromise to be still able to interact with it while keeping it small enough.

![image](https://user-images.githubusercontent.com/70256364/205071534-3703a83a-fe60-48ca-b35f-c9a8bedbb0bc.png)


Closes #1013