### PR TITLE
Fix too permissive query in photo app

### DIFF
--- a/transport_nantes/photo/views.py
+++ b/transport_nantes/photo/views.py
@@ -136,7 +136,9 @@ class PhotoView(FormView):
             # we need to check if the user has already voted for this photo
             # using its session id as well.
             if Vote.objects.filter(
-                    Q(user=user)
+                    # user here could be null hence the
+                    # need to check if user is authenticated
+                    Q(user=user) if user else Q()
                     | Q(tn_session_id=tn_session_id),
                     captcha_succeeded=True,
             ).exists():


### PR DESCRIPTION
The query used to be too permissive :
Q(user=user) could be interpreted as Q(user=<User>) but also Q(user=None).
As every anonymous profile cast a vote with user=None, the direct effect was that as long as one anonymous visitor had voted for a photo, every anonymous was marked as having voted in the past.

Closes #1054