### PR TITLE
Add ensure_csrf_cookie  decorator to PhotoView

### DIFF
--- a/transport_nantes/photo/templates/photo/single_entry.html
+++ b/transport_nantes/photo/templates/photo/single_entry.html
@@ -5,22 +5,27 @@
 {% load crispy_forms_tags %}
 
 {% block localscripts %}
+    {% comment %}
+        The use of Javascript allows us to make AJAX requests to the server
+        without reloading the page. This is useful to avoid reloading the page
+        when the user votes.
+    {% endcomment %}
     {% compress js %}
         <script src="{% static 'photo/js/vote_system.js' %}" defer></script>
-        <script type="text/javascript">
-            {% comment %}Those values are used in vote_system.js{% endcomment %}
-            {% if has_voted %}
-                var has_voted = true;
-            {% else %}
-                var has_voted = false;
-            {% endif %}
-            {% if request.user.is_authenticated %}
-                var is_auth = true;
-            {% else %}
-                var is_auth = false;
-            {% endif %}
-        </script>
     {% endcompress %}
+    <script type="text/javascript">
+        {% comment %}Those values are used in vote_system.js{% endcomment %}
+        {% if has_voted %}
+            var has_voted = true;
+        {% else %}
+            var has_voted = false;
+        {% endif %}
+        {% if request.user.is_authenticated %}
+            var is_auth = true;
+        {% else %}
+            var is_auth = false;
+        {% endif %}
+    </script>
 {% endblock localscripts %}
 
 {% block app_content %}


### PR DESCRIPTION
Private browsing in production doesn't set a csrf cookie, while it's needed for the PhotoView.
The view doesn't contain a html form, but a form is generated and submitted inside the javascript code.

Closes #1050