### PR TITLE
Add Twitter and Facebook social sharing buttons

### DIFF
--- a/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
+++ b/transport_nantes/asso_tn/static/asso_tn/mobilitains.css
@@ -638,3 +638,8 @@ span.centered {
     transform: scale(1.1);
     z-index:3;
 }
+#share-buttons a:visited,
+#share-buttons a:link {
+    color: inherit;
+    text-decoration: none !important;
+}

--- a/transport_nantes/photo/templates/photo/photoentry_list.html
+++ b/transport_nantes/photo/templates/photo/photoentry_list.html
@@ -1,4 +1,5 @@
 {% extends 'asso_tn/base_mobilitain.html' %}
+{% load social %}
 
 {% block app_content %}
 
@@ -45,6 +46,12 @@
             {% endif %}
         </span>
     </div>
+
+    {% block social_buttons %}
+        <div class="my-3">
+            {% socials_share_buttons %}
+        </div>
+    {% endblock social_buttons %}
 
 </main>
 

--- a/transport_nantes/photo/templates/photo/single_entry.html
+++ b/transport_nantes/photo/templates/photo/single_entry.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load compress %}
 {% load crispy_forms_tags %}
+{% load social %}
 
 {% block localscripts %}
     {% comment %}
@@ -91,6 +92,12 @@
         {% tn_markdown photo.pedestrian_issues_md|default:"" %}
 
         {% tn_markdown photo.submitter_info_md|default:"" %}
+
+        {% block social_buttons %}
+            <div class="my-3">
+                {% socials_share_buttons %}
+            </div>
+        {% endblock social_buttons %}
 
         {# Modal form if user never voted #}
         {% if not has_voted %}

--- a/transport_nantes/topicblog/templates/topicblog/content.html
+++ b/transport_nantes/topicblog/templates/topicblog/content.html
@@ -14,6 +14,7 @@
 {% load don %}
 {% load mpanels %}
 {% load newsletter %}
+{% load social %}
 {% block og_image_alt %}{% endblock og_image_alt %}
 {% block og_image_type %}{% endblock og_image_type %}
 {% block og_image_image %}{% endblock og_image_image %}
@@ -82,10 +83,10 @@
           </button>
           {% endif %}
           {# First paragraph of text #}
-          {% tn_markdown page.body_text_1_md %} 
+          {% tn_markdown page.body_text_1_md %}
           {# First CTA, if any #}
           {% if page.cta_1_slug|length > 0 %}
-               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_1_slug %}" 
+               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_1_slug %}"
 		  class="btn donation-button my-3 centered-inline-button">
 		   {{ page.cta_1_label }}
 		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
@@ -96,7 +97,7 @@
           {% tn_markdown page.body_text_2_md %}
           {# Second CTA, if any #}
           {% if page.cta_2_slug|length > 0 %}
-               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_2_slug %}" 
+               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_2_slug %}"
                class="btn donation-button my-3 centered-inline-button">
 		   {{ page.cta_2_label }}
 		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
@@ -114,14 +115,18 @@
           {% tn_markdown page.body_text_3_md %}
           {# Third CTA, if any #}
           {% if page.cta_3_slug|length > 0 %}
-               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_3_slug %}" 
+               <a href="{% url 'topic_blog:view_item_by_slug' page.cta_3_slug %}"
 		  class="btn donation-button my-3 centered-inline-button ">
 		   {{ page.cta_3_label }}
 		   <i class="fa fa-arrow-right" aria-hidden="true"></i>
 	       </a>
           {% endif %}
-
      </div>
+     {% block social_buttons %}
+          <div class="my-3">
+               {% socials_share_buttons %}
+          </div>
+     {% endblock social_buttons %}
 
      {% endblock app_content%}
 </div>
@@ -133,5 +138,5 @@
               {% show_volunteer %}
           </div>
      </div>
-     
+
 {% endblock content %}

--- a/transport_nantes/topicblog/templates/topicblog/content_email.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_email.html
@@ -4,6 +4,7 @@
 {% load don %}
 {% load mpanels %}
 {% load newsletter %}
+{% load social %}
 
 {% block styles %}
      {% comment %}
@@ -83,4 +84,9 @@
           {% endif %}
      </div>
 </div>
+{% block social_buttons %}
+     <div class="my-3">
+          {% socials_share_buttons %}
+     </div>
+{% endblock social_buttons %}
 {% endblock content %}

--- a/transport_nantes/topicblog/templates/topicblog/content_mlp.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_mlp.html
@@ -8,6 +8,7 @@
 {% load don %}
 {% load mpanels %}
 {% load newsletter %}
+{% load social %}
 {% block og_image_alt %}{% endblock og_image_alt %}
 {% block og_image_type %}{% endblock og_image_type %}
 {% block og_image_image %}{% endblock og_image_image %}
@@ -91,6 +92,11 @@
           {% endif %}
 
      </div>
+     {% block social_buttons %}
+          <div class="my-3">
+               {% socials_share_buttons %}
+          </div>
+     {% endblock social_buttons %}
 
      {% endblock app_content%}
 </div>

--- a/transport_nantes/topicblog/templates/topicblog/content_press.html
+++ b/transport_nantes/topicblog/templates/topicblog/content_press.html
@@ -4,6 +4,7 @@
 {% load don %}
 {% load mpanels %}
 {% load newsletter %}
+{% load social %}
 
 {% block styles %}
      {% comment %}
@@ -62,4 +63,9 @@
 	Contact: press@mobilitains.fr
     </div>
 </div>
+{% block social_buttons %}
+     <div class="my-3">
+          {% socials_share_buttons %}
+     </div>
+{% endblock social_buttons %}
 {% endblock content %}

--- a/transport_nantes/topicblog/templatetags/social.py
+++ b/transport_nantes/topicblog/templatetags/social.py
@@ -1,0 +1,26 @@
+from django.template import Library, Template, Context
+from django.utils.safestring import mark_safe
+
+register = Library()
+
+
+@register.simple_tag(takes_context=True)
+def socials_share_buttons(context: dict):
+    html_template = """
+    <div id="share-buttons" class="d-flex flex-row col-12 mb-2 justify-content-center">
+        <i class="fa-solid fa-share-nodes pt-1 mr-5" style="font-size:40px;color:var(--body-text)"></i>
+        <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri|urlencode}}"
+        target="_blank"
+        class="d-flex border-circle p-2 mr-2 font-xl border-blue-light bg-blue-light"
+        style="width:fit-content;color:white;">
+            <i class="fab fa-twitter mx-auto"></i>
+        </a>
+        <a href="http://www.facebook.com/share.php?u={{ request.build_absolute_uri|urlencode }}"
+        target="_blank"
+        class="d-flex border-circle p-2 font-xl border-blue-light bg-blue-light"
+        style="width:fit-content;color:white;">
+            <i class="fab fa-facebook"></i>
+        </a>
+    </div>
+    """
+    return mark_safe(Template(html_template).render(Context(context)))


### PR DESCRIPTION
The base templates are not specific enough to allow a single addition of the buttons. So we add them in the content templates.

Adding it on base_mobilitain.html was unsuccessful, as the buttons would show in undesired places (like the dashboard)