### PR TITLE
Fix case where base_url would include &args= if placed before '?'

### DIFF
--- a/transport_nantes/utm/middleware/utm.py
+++ b/transport_nantes/utm/middleware/utm.py
@@ -31,7 +31,7 @@ class UtmMiddleware:
         if not request.path.startswith('/admin/') and \
            not request.path.startswith('/favicon.ico'):
             utm = UTM()
-            utm.base_url = request.path
+            utm.base_url = request.path.split('&')[0]
             utm.session_id = request.session.get('tn_session', '-')
 
             # If for some reason we receive no user agent data, the

--- a/transport_nantes/utm/tests.py
+++ b/transport_nantes/utm/tests.py
@@ -6,6 +6,7 @@ from django.utils.crypto import get_random_string
 # It has no other real significance in this test.
 k_string_length = 12
 
+
 class SimpleTest(TestCase):
     def setUp(self):
         pass
@@ -21,8 +22,19 @@ class SimpleTest(TestCase):
         the_gclid = get_random_string(k_string_length)
         the_msclkid = get_random_string(k_string_length)
         the_twclid = get_random_string(k_string_length)
-        url = f"/?a=b&utm_campaign={the_campaign}&utm_medium={the_medium}&utm_content={the_content}&c=1&utm_term={the_term}&utm_source={the_source}&gclid={the_gclid}&fbclid={the_fbclid}&twclid={the_twclid}&msclkid={the_msclkid}&aclk={the_aclk}"
-        response = self.client.get(url)
+        url = (
+            f"/?a=b&utm_campaign={the_campaign}&"
+            f"utm_medium={the_medium}"
+            f"&utm_content={the_content}"
+            f"&c=1&utm_term={the_term}"
+            f"&utm_source={the_source}"
+            f"&gclid={the_gclid}"
+            f"&fbclid={the_fbclid}"
+            f"&twclid={the_twclid}"
+            f"&msclkid={the_msclkid}"
+            f"&aclk={the_aclk}"
+        )
+        self.client.get(url)
         objects = UTM.objects.all()
         self.assertEqual(len(objects), 1)
         object = objects[0]
@@ -44,8 +56,14 @@ class SimpleTest(TestCase):
         the_medium = get_random_string(k_string_length)
         the_source = get_random_string(k_string_length)
         the_term = get_random_string(k_string_length)
-        url = f"/?a=b&utm_campaign={the_campaign}&utm_medium={the_medium}&utm_content={the_content}&c=1&utm_term={the_term}&utm_source={the_source}"
-        response = self.client.get(url)
+        url = (
+            f"/?a=b&utm_campaign={the_campaign}"
+            f"&utm_medium={the_medium}"
+            f"&utm_content={the_content}"
+            f"&c=1&utm_term={the_term}"
+            f"&utm_source={the_source}"
+        )
+        self.client.get(url)
         objects = UTM.objects.all()
         self.assertEqual(len(objects), 1)
         object = objects[0]
@@ -60,3 +78,22 @@ class SimpleTest(TestCase):
         self.assertFalse(object.msclkid)
         self.assertFalse(object.twclid)
         self.assertNotEqual("-", object.session_id)
+
+    def test_parse_user_input_with_amp(self):
+        url = (
+            "/tb/p/suite-president-republique-rer-dans-dix-villes/"
+            "&data=05|01|Magazine44@loire-atlantique.fr"
+            "|a533c2de6dec4fc952e808dad1501b18\ " # noqa
+            "|beecb8f7d08247d6bcd90516d6628b41|0|0|638052439229581676|Unknown"
+            "|TWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwi"
+            "LCJXVCI6Mn0=|1000|||"
+            "&sdata=pnSFPZfvqCsxyHKa4I3kiD8TbpBj1FMqXUfy6dWxfUQ=&reserved=0"
+        )
+        self.client.get(url)
+        objects = UTM.objects.all()
+        self.assertEqual(len(objects), 1)
+        object = objects[0]
+        self.assertEqual(
+            object.base_url,
+            "/tb/p/suite-president-republique-rer-dans-dix-villes/"
+        )


### PR DESCRIPTION
Some users (or bots) may try to poke our website with a URL that uses the &args= parameter before the ?args= parameter. This would cause the base_url to be set to the URL with the &args= parameter, which would cause the URL to be invalid.

Closes #1026