### PR TITLE
Make mobilito text mobilitains-gris

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/css/mobilito.css
+++ b/transport_nantes/mobilito/static/mobilito/css/mobilito.css
@@ -11,7 +11,7 @@ h2,
 h3,
 h4,
 p {
-    color: white;
+    color: var(--mobilitains-gris);
     text-align: justify;
     text-justify: auto;
 }


### PR DESCRIPTION
Contrast checker says it's ok, as the ratio is 6.17:1 The WCAG AAA requirement is 7:1, so we're close but not there yet.

Closes #1014