### PR TITLE
Make photo gallery entries even in display

### DIFF
--- a/transport_nantes/photo/templates/photo/photoentry_list.html
+++ b/transport_nantes/photo/templates/photo/photoentry_list.html
@@ -11,14 +11,14 @@
     <div id="entries-container" class="d-flex col-12 justify-content-center flex-wrap">
         {% for photoentry in photoentry_list %}
             <div class="d-flex col-12 col-md-6 col-xl-4 my-3 justify-content-center">
-                <div class="my-auto">
-                    <a href="{% url 'photo:photo_details' photoentry.sha1_name %}">
-                        <img src="{{ photoentry.submitted_photo.url }}"
-                        class="img-fluid thumbnail"
-                        style="filter: drop-shadow(5px 5px 10px #000); max-height:45vh;"
-                        alt="Participation au concours photo">
-                    </a>
-                </div>
+                <a href="{% url 'photo:photo_details' photoentry.sha1_name %}" style="max-height:212px;">
+                    <img src="{{ photoentry.submitted_photo.url }}"
+                    class="thumbnail"
+                    width="100%"
+                    height="100%"
+                    style="filter: drop-shadow(5px 5px 10px #000); object-fit:cover; aspect-ratio: 1/1;"
+                    alt="Participation au concours photo">
+                </a>
             </div>
 
         {% empty %}


### PR DESCRIPTION
It produces a more coherent display, and it's easier to read.

Closes #1067

Before: 

![image](https://user-images.githubusercontent.com/70256364/207577012-a120fcc4-515d-4189-a449-0cf53959e6c3.png)

After:

![image](https://user-images.githubusercontent.com/70256364/207576947-ab573741-b51a-4be1-9f79-383fca41f7c6.png)
