### PR TITLE
Allow users to edit their MobilitoSession's location field

### DIFF
--- a/transport_nantes/mobilito/forms.py
+++ b/transport_nantes/mobilito/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from mobilito.models import MobilitoSession
+
 
 class AddressForm(forms.Form):
     location = forms.CharField(label='Localisation', max_length=1000,
@@ -8,3 +10,9 @@ class AddressForm(forms.Form):
                                  required=False)
     latitude = forms.FloatField(label='Latitude', widget=forms.HiddenInput(),
                                 required=False)
+
+
+class LocationEditForm(forms.ModelForm):
+    class Meta:
+        model = MobilitoSession
+        fields = ['location']

--- a/transport_nantes/mobilito/models.py
+++ b/transport_nantes/mobilito/models.py
@@ -4,6 +4,7 @@ import logging
 
 from django.db import models, IntegrityError
 from django.forms import ValidationError
+from django.urls import reverse
 
 logger = logging.getLogger("django")
 
@@ -75,6 +76,11 @@ class MobilitoSession(models.Model):
                 str(time.monotonic_ns()) + "|" + str(self.user.user.id)
             ).encode('utf-8')
         ).hexdigest()
+
+    def get_absolute_url(self):
+        return reverse(
+            "mobilito:mobilito_session_summary",
+            kwargs={"session_sha1": self.session_sha1})
 
 
 def event_type_validator(value):

--- a/transport_nantes/mobilito/static/mobilito/js/edit_location.js
+++ b/transport_nantes/mobilito/static/mobilito/js/edit_location.js
@@ -1,0 +1,17 @@
+var locationField = document.getElementById("mobilito-session-location");
+var editLocationInputField = document.getElementById("mobilito-session-location-input");
+var editBtn = document.getElementById("mobilito-session-edit-btn");
+var editForm = document.getElementById("mobilito-session-edit-form");
+var cancelBtn = document.getElementById("mobilito-session-cancel-btn");
+
+editBtn.addEventListener("click", function() {
+    locationField.classList.add("d-none");
+    editForm.classList.remove("d-none");
+    editForm.classList.add("d-flex");
+    editLocationInputField.focus();
+});
+cancelBtn.addEventListener("click", function() {
+    locationField.classList.remove("d-none");
+    editForm.classList.remove("d-flex");
+    editForm.classList.add("d-none");
+});

--- a/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
+++ b/transport_nantes/mobilito/templates/mobilito/mobilito_session_summary.html
@@ -27,7 +27,12 @@
           defer>
         </script>
     {% endcompress %}
-
+    {% if can_edit %}
+        <script
+          src="{% static 'mobilito/js/edit_location.js' %}"
+          defer>
+        </script>
+    {% endif %}
     {% if mobilito_session.latitude and mobilito_session.longitude %}
         {# Leaflet JS #}
         <script src="https://unpkg.com/leaflet@1.8.0/dist/leaflet.js"
@@ -53,7 +58,7 @@
 {{ mobilito_session.session_sha1|json_script:'mobilito_session_sha1'}}
     {% if messages %}
         {% for message in messages %}
-        <div class="col-8 col-md-6 mx-auto alert alert-success alert-dismissible fade show" role="alert">
+        <div class="col-8 col-md-6 mx-auto alert alert-{{message.tags}} alert-dismissible fade show" role="alert">
             <span>{{ message }}</span>
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">
               <span aria-hidden="true">&times;</span>
@@ -61,7 +66,7 @@
         </div>
         {% endfor %}
     {% endif %}
-<div class="container">
+<div class="container p-0">
     <div class="d-flex flex-wrap col-12">
 
         <div id="mobilito-share-buttons" class="d-flex flex-row col-12 mb-2">
@@ -83,11 +88,43 @@
         <p class="col-12">
             {{ mobilito_session.start_timestamp|timesince:mobilito_session.end_timestamp }}
             à partir de {{ mobilito_session.start_timestamp|timezone:'Europe/Paris'|date:"l j F Y à G:i" }}.
-            <br/>
-            <b><i class="fa-solid fa-crosshairs"></i> {{ mobilito_session.location }}</b>
         </p>
+        <p id="mobilito-session-location" class="col-12">
+            <b>
+                <i class="fa-solid fa-crosshairs"></i>
+                <span>
+                    {{ mobilito_session.location }}
+                </span>
+                {% if can_edit %}
+                    <span id="mobilito-session-edit-btn" class="p-1 m-3">
+                        <i class="fa-solid fa-pen-to-square"></i>
+                    </span>
+                {% endif %}
+            </b>
+        </p>
+
+        {% if can_edit %}
+            <form id="mobilito-session-edit-form" method="post"
+            action="{% url 'mobilito:edit_location' mobilito_session.session_sha1 %}"
+            class="pl-3 d-none justify-content-center flex-wrap col-12 px-0">
+                {% csrf_token %}
+                <div class="d-flex flex-wrap form-group col-12 pl-0">
+                    <input type="text" class="d-flex col-12 col-md-8 form-control my-auto "
+                    id="mobilito-session-location-input"
+                    name="location"
+                    value="{{ mobilito_session.location }}"
+                    maxlength="1000"
+                    >
+                    <div id="button-holder">
+                        <button type="submit" class="btn donation-button mr-3 ml-0 ml-lg-3 my-2 my-lg-auto ">Sauvegarder</button>
+                        <button type="button" class="btn navigation-button my-2 my-lg-auto" id="mobilito-session-cancel-btn">Annuler</button>
+                    </div>
+                </div>
+            </form>
+        {% endif %}
+        
         {# Dropdown menu #}
-        <div class="dropdown show col-12 mt-n3 mb-2">
+        <div class="dropdown show col-12 mb-2">
             <a href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <i class="fa-solid fa-flag"></i>
             </a>

--- a/transport_nantes/mobilito/urls.py
+++ b/transport_nantes/mobilito/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
     path('merci/', views.ThankYouView.as_view(), name='thanks'),
     path('session/<str:session_sha1>/', views.MobilitoSessionSummaryView.as_view(),
          name='mobilito_session_summary'),
+    path('update-location/<str:session_sha1>/', views.EditLocationView.as_view(),
+         name='edit_location'),
 
     path('session_ts_img/<str:session_sha1>/', views.mobilito_session_timeseries_image,
          name='mobilito_session_timeseries_image'),


### PR DESCRIPTION
This view allows users to edit their mobilito sessions' string location field using an edit button.

The edit button is only visible to the user who created the mobilito session, or the persons with the permission to edit mobilito sessions.

Part of #1022