### PR TITLE
Save lat/lng in form's field before reverse geocoding

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
+++ b/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
@@ -97,6 +97,8 @@ function onMapClick(e) {
         map.removeLayer(marker);
     }
     isLoading = true;
+    $('#id_latitude').val(`${e.latlng.lat}`)
+    $('#id_longitude').val(`${e.latlng.lng}`)
     // Geocode the latitude and longitude of the click and display the address.
     getGeocodedAddress(e.latlng.lat, e.latlng.lng).then(function (data) {
         if (data.status === "OK") {
@@ -104,8 +106,6 @@ function onMapClick(e) {
             marker = L.marker(e.latlng).addTo(map)
                 .bindPopup(`${addr}`).openPopup();
             $('#id_location').val(`${addr}`)
-            $('#id_latitude').val(`${e.latlng.lat}`)
-            $('#id_longitude').val(`${e.latlng.lng}`)
         } else {
             // Maps API has a spec for status codes, see :
             // https://developers.google.com/maps/documentation/geocoding/requests-reverse-geocoding#reverse-status-codes


### PR DESCRIPTION
If the reverse geocoding failed, we would not have the lat/lng in the form's fields, while we had access to this information. By setting the field's values before the reverse geocoding, we can be sure to have the lat/lng even if the reverse geocoding failed.

Closes #1084