### PR TITLE
Improve responsive in photo gallery

### DIFF
--- a/transport_nantes/photo/static/photo/css/single_entry.css
+++ b/transport_nantes/photo/static/photo/css/single_entry.css
@@ -33,5 +33,15 @@
   width: 100%;
   max-width: 800px;
   margin: auto;
-  max-height: 60vh;
+  height: 50vh;
+}
+@media screen and (max-width: 800px) {
+  .photo-container {
+    height: 40vh;
+  }
+}
+@media screen and (max-width: 600px) {
+  .photo-container {
+    height: 30vh;
+  }
 }

--- a/transport_nantes/photo/templates/photo/single_entry.html
+++ b/transport_nantes/photo/templates/photo/single_entry.html
@@ -56,7 +56,7 @@
             <i class="fa-solid fa-chevron-left"></i>
             Retour à la galerie
         </a>
-        <div class="photo-container" style="position: relative; height:50vh;">
+        <div class="photo-container">
             <img src="{{ photo.submitted_photo.url }}"
             alt="Photo soumise à l'occasion de l'opération piéton"
             class=""


### PR DESCRIPTION
The text under the picture would get sometimes pushed too far at the bottom and some may think there isn't even a text.

Closes #1104