### PR TITLE
Remove the alert and place marker even without reverse geocoding

### DIFF
--- a/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
+++ b/transport_nantes/mobilito/static/mobilito/js/geolocation_map.js
@@ -99,21 +99,17 @@ function onMapClick(e) {
     isLoading = true;
     $('#id_latitude').val(`${e.latlng.lat}`)
     $('#id_longitude').val(`${e.latlng.lng}`)
+    marker = L.marker(e.latlng).addTo(map)
     // Geocode the latitude and longitude of the click and display the address.
     getGeocodedAddress(e.latlng.lat, e.latlng.lng).then(function (data) {
+        // Maps API has a spec for status codes, see :
+        // https://developers.google.com/maps/documentation/geocoding/requests-reverse-geocoding#reverse-status-codes
         if (data.status === "OK") {
             let addr = data.results[0].formatted_address;
-            marker = L.marker(e.latlng).addTo(map)
-                .bindPopup(`${addr}`).openPopup();
+            marker.bindPopup(`${addr}`).openPopup();
             $('#id_location').val(`${addr}`)
         } else {
-            // Maps API has a spec for status codes, see :
-            // https://developers.google.com/maps/documentation/geocoding/requests-reverse-geocoding#reverse-status-codes
-            // If the status is not OK, we display the error message,
-            // as the result is that the user doesn't get a formatted address.
-            // The goal of this alert is to inform the user something went wrong
-            // and not really to handle the error.
-            alert("La localisation n'est pas disponible pour le moment.")
+            $('#id_location').val("")
         }
         isLoading = false;
     });


### PR DESCRIPTION
The marker now moves as the user clicks on the map. It shows the address if the reverse geocoding is successful.

Closes #1114
Closes #1113