### PR TITLE
Add non-mandatory settings for ngrok

### DIFF
--- a/transport_nantes/transport_nantes/settings.py
+++ b/transport_nantes/transport_nantes/settings.py
@@ -29,6 +29,21 @@ ADMIN = [
 ]
 
 ALLOWED_HOSTS = settings_local.ALLOWED_HOSTS
+# This is a list of trusted origins for CSRF protection.
+# https://docs.djangoproject.com/en/4.1/ref/settings/#csrf-trusted-origins
+# It defaults to an empty list, but you may add your own origins in dev
+# using settings_local.py. This allows you to use ngrok or similar.
+# Ngrok allows you to open a tunnel and make accessible your local dev branch
+# through a browser, notably to make sure it displays well and works on
+# your phone before even pushing to beta.
+# It avoids too many pushes to beta that may affect the database and require
+# a restore.
+# see https://ngrok.com/ for usage.
+if DEBUG and ROLE == "dev":
+    CSRF_TRUSTED_ORIGINS = (
+        getattr(settings_local, "CSRF_TRUSTED_ORIGINS", None) or []
+    )
+
 # Requirement for Django-debug-toolbar
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configure-internal-ips
 INTERNAL_IPS = [


### PR DESCRIPTION
The getattr allows to have a default value if the setting is not even defined in the settings_local.py file, which allows us to even not have to define on infra.

This feature is for dev env only and meant to ease the use of ngrok for local development.
Allowing ngrok subdomains in CSRF_TRUSTED_ORIGIN allows to use POST requests from ngrok subdomains (notably to login)

Because this is locked to a dev environment only, this doesn't raise any security issue on production.

closes #1124