### PR TITLE
Benja mobilito session feed 1115

### DIFF
--- a/transport_nantes/mobilito/templates/mobilito/index.html
+++ b/transport_nantes/mobilito/templates/mobilito/index.html
@@ -71,6 +71,17 @@
 		</a>
 	</div>
 	{% endif %}{# ################ end ################ #}
+
+	<section class="mt-5">
+		<h1 style="font-size: 1.4em; text-align: left;">Les dernières contributions</h1>
+		<div class="d-flex flex-column col-12 p-0">
+			{% for session_obj in latest_sessions %}
+				{% include "mobilito/session_history_line.html" with session=session_obj %}
+			{% empty %}
+				<p>Aucune session enregistrée</p>
+			{% endfor %}
+		</div>
+	</section>
 </main>
 
 {% endblock app_content %}

--- a/transport_nantes/mobilito/templates/mobilito/index.html
+++ b/transport_nantes/mobilito/templates/mobilito/index.html
@@ -29,18 +29,18 @@
 		</div>
 	</div>
 	{% if tutorial_done %}{# ################ not newbie ################ #}
-		<div class="d-flex col-12 flex-row flex-nowrap justify-content-around">
-			<a class="btn donation-button mx-2" role="button" 
+		<div class="d-flex col-12 p-0 flex-wrap justify-content-around">
+			<a class="col-12 col-md-3 btn donation-button m-2" role="button" 
 			href="{% url 'mobilito:address_form' %}">
 				Je commence à enregistrer
 			</a>
-			<a class="btn donation-button mx-2" role="button"
+			<a class="col-12 col-md-3 btn donation-button m-2" role="button"
 			href="{% url 'mobilito:tutorial' 'presentation' %}">
 				Je passe vite par le tutoriel
 			</a>
 			{% if has_sessions_history %}
-				<a class="btn donation-button mx-2" role="button" 
-				href="{% url 'mobilito:my_sessions' %}">
+				<a class="col-12 col-md-3 btn donation-button m-2" role="button" 
+				href="{% url 'mobilito:user_sessions' mobilito_user.user.username %}">
 					Voir mon historique
 				</a>
 			{% endif %}
@@ -54,7 +54,7 @@
 		</a>
 		{% if has_sessions_history %}
 			<a class="btn donation-button mx-2" role="button" 
-			href="{% url 'mobilito:my_sessions' %}">
+			href="{% url 'mobilito:user_sessions' mobilito_user.user.username %}">
 				Voir mon historique
 			</a>
 		{% endif %}

--- a/transport_nantes/mobilito/templates/mobilito/session_history.html
+++ b/transport_nantes/mobilito/templates/mobilito/session_history.html
@@ -13,17 +13,8 @@
             </a>
         </div>
         <h1 class="font-xl">Mes sessions mobilito</h1>
-        {% for session in mobilito_sessions %}
-            <article>
-                <h2 style="font-size: 1.2em;">
-                    <a href="{{ session.get_absolute_url }}" style="color:inherit;">
-                        <i class="fa-solid fa-crosshairs"></i>
-                        {{ session.location|default:"Pas d'adresse" }}
-                    </a>
-                </h2>
-                <p class="mb-0"><i>{{ session.start_timestamp|date:"d/m/Y à H:i" }}</i></p>
-            </article>
-            <hr class="w-100" />
+        {% for session_obj in mobilito_sessions %}
+            {% include "mobilito/session_history_line.html" with session=session_obj %}
         {% empty %}
             <p class="text-center">Aucune session enregistrée</p>
         {% endfor %}

--- a/transport_nantes/mobilito/templates/mobilito/session_history_line.html
+++ b/transport_nantes/mobilito/templates/mobilito/session_history_line.html
@@ -1,0 +1,23 @@
+{% comment %} 
+Requires a MobilitoSession as 'session'
+
+This is meant to be a reusable component.
+{% endcomment %}
+<article>
+    <h2 style="font-size: 1.2em;">
+        <a href="{{ session.get_absolute_url }}" style="color:inherit;">
+            <i class="fa-solid fa-crosshairs"></i>
+            {{ session.location|default:"Pas d'adresse" }}
+        </a>
+    </h2>
+    <p class="m-0">
+        <i>
+            <a href="{% url 'mobilito:user_sessions' session.user.user.username %}" 
+            style="color:inherit; font-size: 0.9rem">
+                Faite par {{ session.user.user.username }}
+            </a>
+        </i>
+    </p>
+    <p class="mb-0"><i>{{ session.start_timestamp|date:"d/m/Y à H:i" }}</i></p>
+</article>
+<hr class="w-100" />

--- a/transport_nantes/mobilito/urls.py
+++ b/transport_nantes/mobilito/urls.py
@@ -18,9 +18,9 @@ urlpatterns = [
     path("enregistrement/", views.RecordingView.as_view(), name="recording"),
     path("merci/", views.ThankYouView.as_view(), name="thanks"),
     path(
-        "mes-sessions/",
-        views.MySessionHistoryView.as_view(),
-        name="my_sessions",
+        "sessions/u/<str:username>/",
+        views.SessionHistoryView.as_view(),
+        name="user_sessions",
     ),
     path(
         "session/<str:session_sha1>/",

--- a/transport_nantes/mobilito/views.py
+++ b/transport_nantes/mobilito/views.py
@@ -197,6 +197,7 @@ class MobilitoView(TemplateView):
             context["has_sessions_history"] = (
                 MobilitoSession.objects.filter(user=mobilito_user).count() > 0
             )
+            context["mobilito_user"] = mobilito_user
         return context
 
     def get(self, request, *args, **kwargs):
@@ -970,16 +971,21 @@ def flag_session(request: HttpRequest, **kwargs) -> HttpResponse:
         return HttpResponse(status=405)
 
 
-class MySessionHistoryView(LoginRequiredMixin, ListView):
-    """Display one's own session history."""
+class SessionHistoryView(ListView):
+    """Display one's sessions history."""
 
     model = MobilitoSession
-    template_name = "mobilito/my_session_history.html"
+    template_name = "mobilito/session_history.html"
     context_object_name = "mobilito_sessions"
     paginate_by = 10
 
     def get_queryset(self):
         """Return the user's sessions."""
+        username = self.kwargs.get("username")
+        searched_user = get_object_or_404(
+            MobilitoUser, user__username=username
+        )
+
         return MobilitoSession.objects.filter(
-            user__user=self.request.user
+            user=searched_user, published=True
         ).order_by("-start_timestamp")

--- a/transport_nantes/mobilito/views.py
+++ b/transport_nantes/mobilito/views.py
@@ -198,6 +198,7 @@ class MobilitoView(TemplateView):
                 MobilitoSession.objects.filter(user=mobilito_user).count() > 0
             )
             context["mobilito_user"] = mobilito_user
+        context["latest_sessions"] = self.get_latest_sessions()
         return context
 
     def get(self, request, *args, **kwargs):
@@ -210,6 +211,14 @@ class MobilitoView(TemplateView):
         else:
             context["tutorial_done"] = True
         return self.render_to_response(context)
+
+    def get_latest_sessions(self):
+        """Return the latest pulished sessions"""
+        return (
+            MobilitoSession.objects.filter(published=True)
+            .order_by("-start_timestamp")
+            .all()[:10]
+        )
 
 
 class TutorialView(TemplateView):


### PR DESCRIPTION
This PR adds :

* A publicly accessible history for any given user using the sha1_identifier field (`/mobilito/session/u/<sha1_identifier>`)
* A username display under the location. This username isn't editable just yet, that is to come in later commits.

Hotspots for this PR : 
* I changed responsive a bit to fit a 3rd button to access your own history.
* I added a "Contributions récentes" feed on mobilito's index, tell me what you think. It's the 10 latest contributions.
* Username display: Pay closer attention to how username is fetched, I implemented a @property and a setter on this field.

Closes #1115 